### PR TITLE
[Han] 이미지뷰 사용 -> 커스텀뷰 사용, 사각형 생성, 선택, 투명도 변경 기능 구현 (MVP, repository, LiveData)

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-03-02T06:47:28.502273600Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-03-03T17:53:20.335030800Z" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/drawable/textview_background_1.xml" value="0.2135" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-land/activity_main.xml" value="0.16510416666666666" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_main.xml" value="0.22" />
-        <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_rectangle.xml" value="0.2" />
+        <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_rectangle.xml" value="0.25" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout/activity_main.xml" value="0.25" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout/activity_rectangle.xml" value="0.28958333333333336" />
       </map>

--- a/README.md
+++ b/README.md
@@ -17,5 +17,12 @@
 
 ***
 
-## 사각형 랜덤 위치 생성
-![image](https://user-images.githubusercontent.com/69443895/156312309-a484c70d-1858-4ad9-b5c0-302bae4c59fc.png)
+## 사각형 랜덤 위치 생성, 선택 시 테두리 처리, 투명도 변경, 배경 선택 시 사각형 선택 비활성화
+![image](https://user-images.githubusercontent.com/69443895/156705889-6db11b25-b2c0-41bb-9125-8f4bb67c99db.png)
+
+![image](https://user-images.githubusercontent.com/69443895/156705968-5f72b77e-bb92-4bbc-ba20-f91cc8b0c4e9.png)
+
+![image](https://user-images.githubusercontent.com/69443895/156706009-e09f69cc-ea6f-4119-9b3c-7bf7967ac7a7.png)
+
+![image](https://user-images.githubusercontent.com/69443895/156706051-052f1df0-4e53-463a-99a5-a88d21013977.png)
+

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.codesquad_han.kotlin_drawingapp">
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepository.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepository.kt
@@ -7,4 +7,6 @@ interface RectangleRepository {
     fun addRectangle()
 
     fun getRectangleList() : MutableList<Rectangle>
+
+    fun updateTransparency(id: String, transparency: Int)
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepository.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepository.kt
@@ -1,0 +1,10 @@
+package com.codesquad_han.kotlin_drawingapp.data
+
+import com.codesquad_han.kotlin_drawingapp.model.Rectangle
+
+interface RectangleRepository {
+
+    fun addRectangle()
+
+    fun getRectangleList() : MutableList<Rectangle>
+}

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepositoryImpl.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.codesquad_han.kotlin_drawingapp.data
+
+import com.codesquad_han.kotlin_drawingapp.model.Plane
+import com.codesquad_han.kotlin_drawingapp.model.Rectangle
+
+class RectangleRepositoryImpl(var plane: Plane) : RectangleRepository {
+    override fun addRectangle() {
+        plane.generateRectangle()
+    }
+
+    override fun getRectangleList() = plane.returnRectangleList()
+}

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepositoryImpl.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepositoryImpl.kt
@@ -9,4 +9,8 @@ class RectangleRepositoryImpl(var plane: Plane) : RectangleRepository {
     }
 
     override fun getRectangleList() = plane.returnRectangleList()
+
+    override fun updateTransparency(id: String, transparency: Int) {
+        plane.updateTransparency(id, transparency)
+    }
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Plane.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Plane.kt
@@ -10,4 +10,14 @@ class Plane(rectangleFactory: RectangleFactory) {
     }
 
     fun returnRectangleList() = rectangleList
+
+    fun updateTransparency(id: String, transparency: Int) {
+        rectangleList.forEach {
+            if (it.id == id) {
+                it.transparency.transparency = transparency
+            }
+        }
+    }
+
+    fun returnRectangleCount() = rectangleList.size
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Plane.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Plane.kt
@@ -1,25 +1,13 @@
 package com.codesquad_han.kotlin_drawingapp.model
 
-import android.widget.ImageView
-
 class Plane(rectangleFactory: RectangleFactory) {
-    private var rectangleArrayList = ArrayList<RectangleImageviewData>()
+    private var rectangleList = mutableListOf<Rectangle>()
     private var rectangleFactory = rectangleFactory
 
-    fun generateRectangle() : Rectangle{
+    fun generateRectangle() {
         val rectangle = rectangleFactory.generateRectangle()
-        rectangleArrayList.add(RectangleImageviewData(rectangle, null, false))
-        return rectangle
+        rectangleList.add(rectangle)
     }
 
-    fun saveImageView(imageView: ImageView){
-        rectangleArrayList[rectangleArrayList.size-1].imageView = imageView
-    }
-
-    fun selectImageView(imageView: ImageView) : ArrayList<RectangleImageviewData>{
-        rectangleArrayList.forEach {
-            it.selected = it.imageView == imageView
-        }
-        return rectangleArrayList
-    }
+    fun returnRectangleList() = rectangleList
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Rectangle.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Rectangle.kt
@@ -7,20 +7,16 @@ class Rectangle(
     backgroundColor: BackgroundColor,
     transparency: Transparency
 ) {
-    private var id = id
-    private var point = point
-    private var size = size
-    private var backgroundColor = backgroundColor
-    private var transparency = transparency
+    val id = id
+    val point = point
+    val size = size
+    val backgroundColor = backgroundColor
+    val transparency = transparency
 
     override fun toString(): String {
         return "($id), X:${point.x},Y:${point.y}, W:${size.width},H:${size.height}, R:${backgroundColor.r},G:${backgroundColor.g},${backgroundColor.b}, " +
                 "Alpha:${transparency.transparency}"
     }
 
-    fun getId() = id
-    fun getPoint() = point
-    fun getSize() = size
-    fun getBackgroundColor() = backgroundColor
-    fun getTransparency() = transparency
+
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/RectangleFactory.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/RectangleFactory.kt
@@ -10,12 +10,11 @@ class RectangleFactory(x: Int, y: Int) {
         return Rectangle(
             id,
             Point((0..x).random(), (0..y).random()),
-            Size(150, 120),
+            Size(300, 240),  // Pixcel C API 31 에서 1dp = 2px, 따라서 2배해준 값 사용
             BackgroundColor((0..255).random(), (0..255).random(), (0..255).random()),
             Transparency((1..10).random())
         )
     }
-
 
     fun getRandomString(length: Int): String {
         val charset = ('a'..'z') + ('A'..'Z') + ('0'..'9')

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -66,17 +66,20 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
 
         setBtnMakeRectangle()
         setTransparencySlider()
+
     }
 
-    // presenter 초기화
+    // presenter 초기화 및 livedata 옵저버 등록
     fun initPresenter(rectangleFactory: RectangleFactory) {
         presenter = RectanglePresenter(RectangleRepositoryImpl(Plane(rectangleFactory)), this)
+        presenter.liveRectangleList.observe(this) {
+            showRectangle(it)
+        }
     }
 
     fun setBtnMakeRectangle() {
         binding.btnGenerateRectangle?.setOnClickListener {
             presenter.start()
-            presenter.getRectangleList()
         }
     }
 
@@ -126,7 +129,6 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
                 @SuppressLint("RestrictedApi")
                 override fun onStopTrackingTouch(slider: Slider) {
                     presenter.updateTransparency(SELECTED_RECTANGLE_ID, slider.value.toInt())
-                    presenter.getRectangleList()
                 }
 
             })

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
+import android.view.View
 import android.view.ViewTreeObserver
 import com.codesquad_han.kotlin_drawingapp.data.RectangleRepositoryImpl
 import com.codesquad_han.kotlin_drawingapp.databinding.ActivityRectangleBinding
@@ -85,9 +86,26 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
 
     }
 
-    override fun clickDrawingView() {
-        // 드로잉 커스텀뷰 부분 터치 시
+    override fun clickDrawingView(color: String, alpha: Int, selected: Boolean, id: String) {
+        if(selected){
+            binding.constraintLayoutControl?.let{
+                it.visibility = View.VISIBLE
+            }
+            binding.tvBackgroundColor?.let{
+                it.text = color
+            }
+            binding.sliderTransparency?.let{
+                it.value = alpha.toFloat()
+            }
 
+            // id 값을 활용해 현재 선택된 사각형 투명도 데이터 업데이트 후 뷰에 반영시키기
+
+        }
+        else{
+            binding.constraintLayoutControl?.let {
+                it.visibility = View.INVISIBLE
+            }
+        }
     }
 
     fun ConvertDPtoPX(context: Context, dp: Int): Int {

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -12,6 +12,7 @@ import com.codesquad_han.kotlin_drawingapp.databinding.ActivityRectangleBinding
 import com.codesquad_han.kotlin_drawingapp.model.Plane
 import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 import com.codesquad_han.kotlin_drawingapp.model.RectangleFactory
+import com.google.android.material.slider.Slider
 
 class RectangleActivity : AppCompatActivity(), RectangleContract.View, RectangleViewClickInterface {
 
@@ -23,6 +24,8 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
 
     private var RECTANGLE_WIDTH = 0
     private var RECTANGLE_HEIGHT = 0
+
+    private lateinit var SELECTED_RECTANGLE_ID: String
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -62,6 +65,7 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
         }
 
         setBtnMakeRectangle()
+        setTransparencySlider()
     }
 
     // presenter 초기화
@@ -77,31 +81,29 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
     }
 
     // 만든 사각형 커스텀 뷰에 추가로 그리기
-    override fun showRectangle(updatedRectangleList : MutableList<Rectangle>) {
+    override fun showRectangle(updatedRectangleList: MutableList<Rectangle>) {
         Log.d("AppTest", "update rectangle list size : ${updatedRectangleList.size}")
-        binding.rectangleDrawingView?.drawRectangle(updatedRectangleList)
+        binding.rectangleDrawingView?.let {
+            it.drawRectangle(updatedRectangleList)
+        }
     }
 
-    override fun showSelectedRectangle() {
-
-    }
 
     override fun clickDrawingView(color: String, alpha: Int, selected: Boolean, id: String) {
-        if(selected){
-            binding.constraintLayoutControl?.let{
+        if (selected) {
+            binding.constraintLayoutControl?.let {
                 it.visibility = View.VISIBLE
             }
-            binding.tvBackgroundColor?.let{
+            binding.tvBackgroundColor?.let {
                 it.text = color
             }
-            binding.sliderTransparency?.let{
+            binding.sliderTransparency?.let {
                 it.value = alpha.toFloat()
             }
 
             // id 값을 활용해 현재 선택된 사각형 투명도 데이터 업데이트 후 뷰에 반영시키기
-
-        }
-        else{
+            SELECTED_RECTANGLE_ID = id
+        } else {
             binding.constraintLayoutControl?.let {
                 it.visibility = View.INVISIBLE
             }
@@ -111,6 +113,24 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
     fun ConvertDPtoPX(context: Context, dp: Int): Int {
         val density = context.resources.displayMetrics.density
         return Math.round(dp.toFloat() * density)
+    }
+
+    fun setTransparencySlider() {
+        binding.sliderTransparency?.let {
+            it.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
+                @SuppressLint("RestrictedApi")
+                override fun onStartTrackingTouch(slider: Slider) {
+
+                }
+
+                @SuppressLint("RestrictedApi")
+                override fun onStopTrackingTouch(slider: Slider) {
+                    presenter.updateTransparency(SELECTED_RECTANGLE_ID, slider.value.toInt())
+                    presenter.getRectangleList()
+                }
+
+            })
+        }
     }
 
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -1,18 +1,22 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.view.ViewTreeObserver
+import androidx.activity.result.contract.ActivityResultContracts
 import com.codesquad_han.kotlin_drawingapp.data.RectangleRepositoryImpl
 import com.codesquad_han.kotlin_drawingapp.databinding.ActivityRectangleBinding
 import com.codesquad_han.kotlin_drawingapp.model.Plane
 import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 import com.codesquad_han.kotlin_drawingapp.model.RectangleFactory
 import com.google.android.material.slider.Slider
+import com.google.android.material.snackbar.Snackbar
 
 class RectangleActivity : AppCompatActivity(), RectangleContract.View, RectangleViewClickInterface {
 
@@ -66,7 +70,7 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
 
         setBtnMakeRectangle()
         setTransparencySlider()
-
+        setBtnGallery()
     }
 
     // presenter 초기화 및 livedata 옵저버 등록
@@ -103,12 +107,18 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
             binding.sliderTransparency?.let {
                 it.value = alpha.toFloat()
             }
+            binding.btnOpenGallery?.let {
+                it.isEnabled = true
+            }
 
             // id 값을 활용해 현재 선택된 사각형 투명도 데이터 업데이트 후 뷰에 반영시키기
             SELECTED_RECTANGLE_ID = id
         } else {
             binding.constraintLayoutControl?.let {
                 it.visibility = View.INVISIBLE
+            }
+            binding.btnOpenGallery?.let {
+                it.isEnabled = false
             }
         }
     }
@@ -132,6 +142,39 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
                 }
 
             })
+        }
+    }
+
+    fun setBtnGallery() {
+        val getContent = registerForActivityResult(ActivityResultContracts.StartActivityForResult()){
+            if(it.resultCode == RESULT_OK){
+                Log.d("AppTest", "RectangleActivity/ data : ${it.data?.data}")
+                // uri 전달하기!!!!
+
+            }
+            else{
+                Snackbar.make(binding.root, "사진 불러오기 취소", Snackbar.LENGTH_SHORT).show()
+            }
+        }
+
+        val requestPermissionLauncher =
+            registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+                isGranted: Boolean ->
+                if(isGranted){
+                    val intent = Intent(Intent.ACTION_PICK)
+                    intent.type = "image/*"
+                    getContent.launch(Intent.createChooser(intent, "Gallery"))
+                }
+                else{
+                    Snackbar.make(binding.root, "갤러리 접근 권한이 승인되지 않았습니다", Snackbar.LENGTH_SHORT).show()
+                }
+            }
+
+        binding.btnOpenGallery?.let {
+           it.setOnClickListener {
+                // 갤러리 열고 uri 가져오기 구현하기
+                requestPermissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+            }
         }
     }
 

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -44,9 +44,6 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
             it.viewTreeObserver.addOnGlobalLayoutListener(object :
                 ViewTreeObserver.OnGlobalLayoutListener {
                 override fun onGlobalLayout() {
-                    binding.rectangleDrawingView!!.viewTreeObserver.removeOnGlobalLayoutListener(
-                        this
-                    )
                     val width = binding.rectangleDrawingView!!.width - RECTANGLE_WIDTH
                     val height = binding.rectangleDrawingView!!.height - RECTANGLE_HEIGHT
 
@@ -54,6 +51,9 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
                     Log.d("AppTest", "width:$width, height:$height")
 
                     initPresenter(rectangleFactory)
+
+                    // 리스너 해제
+                    it.viewTreeObserver.removeOnGlobalLayoutListener(this)
                 }
             })
         }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -32,7 +32,6 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
 
         RECTANGLE_WIDTH = ConvertDPtoPX(this, 150)
         RECTANGLE_HEIGHT = ConvertDPtoPX(this, 120)
-
         Log.d("AppTest", "${this.window.decorView.height}")
         Log.d("AppTest", "MainActivity/ ${RECTANGLE_WIDTH}, ${RECTANGLE_HEIGHT}")
 
@@ -53,6 +52,12 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
                     initPresenter(rectangleFactory)
                 }
             })
+        }
+
+        // 커스텀뷰 에서 터치이벤트 전달 & 테두리 페인트 초기화
+        binding.rectangleDrawingView?.let {
+            it.drawingViewInit()
+            it.setClickListener(this)
         }
 
         setBtnMakeRectangle()

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -2,29 +2,26 @@ package com.codesquad_han.kotlin_drawingapp.rectangle
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.res.ColorStateList
-import android.graphics.Color
-import android.graphics.drawable.GradientDrawable
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
-import android.view.MotionEvent
 import android.view.ViewTreeObserver
-import android.widget.ImageView
-import android.widget.LinearLayout
-import com.codesquad_han.kotlin_drawingapp.R
+import com.codesquad_han.kotlin_drawingapp.data.RectangleRepositoryImpl
 import com.codesquad_han.kotlin_drawingapp.databinding.ActivityRectangleBinding
 import com.codesquad_han.kotlin_drawingapp.model.Plane
+import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 import com.codesquad_han.kotlin_drawingapp.model.RectangleFactory
-import com.codesquad_han.kotlin_drawingapp.model.RectangleImageviewData
 
-class RectangleActivity : AppCompatActivity(), RectangleContract.View {
+class RectangleActivity : AppCompatActivity(), RectangleContract.View, RectangleViewClickInterface {
 
     private lateinit var binding: ActivityRectangleBinding
 
     private lateinit var rectangleFactory: RectangleFactory
 
     override lateinit var presenter: RectangleContract.Presenter
+
+    private var RECTANGLE_WIDTH = 0
+    private var RECTANGLE_HEIGHT = 0
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -33,107 +30,64 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View {
         binding = ActivityRectangleBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        var widthMinus = ConvertDPtoPX(this, 150)
+        RECTANGLE_WIDTH = ConvertDPtoPX(this, 150)
+        RECTANGLE_HEIGHT = ConvertDPtoPX(this, 120)
 
         Log.d("AppTest", "${this.window.decorView.height}")
+        Log.d("AppTest", "MainActivity/ ${RECTANGLE_WIDTH}, ${RECTANGLE_HEIGHT}")
 
 
-        binding.frameLayoutDraw!!.viewTreeObserver.addOnGlobalLayoutListener(object :
-            ViewTreeObserver.OnGlobalLayoutListener {
-            override fun onGlobalLayout() {
-                binding.frameLayoutDraw!!.viewTreeObserver.removeOnGlobalLayoutListener(this)
-                val width = binding.frameLayoutDraw!!.width - widthMinus
-                val height = binding.frameLayoutDraw!!.height
-                rectangleFactory = RectangleFactory(width, height)
-                Log.d("AppTest", "width:$width, height:$height")
+        binding.rectangleDrawingView?.let {
+            it.viewTreeObserver.addOnGlobalLayoutListener(object :
+                ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    binding.rectangleDrawingView!!.viewTreeObserver.removeOnGlobalLayoutListener(
+                        this
+                    )
+                    val width = binding.rectangleDrawingView!!.width - RECTANGLE_WIDTH
+                    val height = binding.rectangleDrawingView!!.height - RECTANGLE_HEIGHT
 
-                initPresenter(rectangleFactory)
-            }
-        })
+                    rectangleFactory = RectangleFactory(width, height)
+                    Log.d("AppTest", "width:$width, height:$height")
 
-        binding.frameLayoutDraw!!.setOnTouchListener { view, motionEvent ->
-            if (motionEvent.action == MotionEvent.ACTION_DOWN) {
-                Log.d("AppTest", "view.x : ${view.x}, view.y : ${view.y}")
-                Log.d("AppTest", "event.x : ${motionEvent.x}, event.y : ${motionEvent.y}")
-                Log.d(
-                    "AppTest",
-                    "event.rawX : ${motionEvent.rawX}, event.rawY : ${motionEvent.rawY}"
-                )
-            }
-            true
+                    initPresenter(rectangleFactory)
+                }
+            })
         }
 
-        //setBtnMakeRectangle()
-        setBtnMakeRectangle2()
-
+        setBtnMakeRectangle()
     }
 
     // presenter 초기화
     fun initPresenter(rectangleFactory: RectangleFactory) {
-        presenter = RectanglePresenter(Plane(rectangleFactory), this)
+        presenter = RectanglePresenter(RectangleRepositoryImpl(Plane(rectangleFactory)), this)
     }
 
     fun setBtnMakeRectangle() {
-        binding.btnGenerateRectangle!!.setOnClickListener {
-            makeRectangle(4)
-        }
-    }
-
-    fun makeRectangle(num: Int) {
-        (1..num).forEach {
-            Log.d("AppTest", "Rect$it ${rectangleFactory.generateRectangle().toString()}")
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        Log.d("AppTest", "$this/ onResume")
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////////////////////////
-    fun setBtnMakeRectangle2(){
         binding.btnGenerateRectangle?.setOnClickListener {
             presenter.start()
+            presenter.getRectangleList()
         }
     }
 
-    // 만든 사각형 정보 가져와서 이미지 뷰 동적으로 생성하기
-    override fun showRectangle(width: Int, height: Int, x:Int, y:Int, colorStr: String) {
-        val dynamicImageView = ImageView(this)
-        val layoutParams = LinearLayout.LayoutParams(ConvertDPtoPX(this, width), ConvertDPtoPX(this, height))
-        dynamicImageView.layoutParams = layoutParams
-        dynamicImageView.setBackgroundResource(R.drawable.stroke1)
+    // 만든 사각형 커스텀 뷰에 추가로 그리기
+    override fun showRectangle(updatedRectangleList : MutableList<Rectangle>) {
+        Log.d("AppTest", "update rectangle list size : ${updatedRectangleList.size}")
+        binding.rectangleDrawingView?.drawRectangle(updatedRectangleList)
+    }
 
-        var gradientDrawable = dynamicImageView.background as GradientDrawable
-        //gradientDrawable.setColor(ContextCompat.getColor(this, R.color.purple_200))
-        gradientDrawable.setColor(Color.parseColor("#$colorStr"))
+    override fun showSelectedRectangle() {
 
-        dynamicImageView.x = x.toFloat() // 사각형 왼쪽 상단 좌표
-        dynamicImageView.y = y.toFloat()
+    }
 
-        presenter.saveImageView(dynamicImageView)
-        dynamicImageView.setOnClickListener {
-            presenter.selectRectangleImageView(dynamicImageView)
-        }
+    override fun clickDrawingView() {
+        // 드로잉 커스텀뷰 부분 터치 시
 
-        binding.frameLayoutDraw!!.addView(dynamicImageView)
     }
 
     fun ConvertDPtoPX(context: Context, dp: Int): Int {
         val density = context.resources.displayMetrics.density
         return Math.round(dp.toFloat() * density)
-    }
-
-    override fun showSelectedRectangle(rectangleList: ArrayList<RectangleImageviewData>) {
-        rectangleList.forEach {
-            var gradientDrawable = it.imageView?.background as GradientDrawable
-            if(it.selected){
-                gradientDrawable.setStroke(5, Color.RED)
-            }
-            else{
-                gradientDrawable.setStroke(5, null)
-            }
-        }
     }
 
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
@@ -9,14 +9,14 @@ import com.codesquad_han.kotlin_drawingapp.model.RectangleImageviewData
 interface RectangleContract {
 
     interface View : BaseView<Presenter> {
-        fun showRectangle(updatedRectangleList : MutableList<Rectangle>)   // 추가된 사각형을 포함한 리스트 받아와서 새로 그리기
-
-        fun showSelectedRectangle()
+        fun showRectangle(updatedRectangleList: MutableList<Rectangle>)   // 추가된 사각형을 포함한 리스트 받아와서 새로 그리기
     }
 
     interface Presenter : BasePresenter {
         fun addRectangle() // 사각형 생성
 
         fun getRectangleList()
+
+        fun updateTransparency(id: String, transparency: Int) // 선택한 사각형 투명도 변경
     }
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
@@ -3,23 +3,20 @@ package com.codesquad_han.kotlin_drawingapp.rectangle
 import android.widget.ImageView
 import com.codesquad_han.kotlin_drawingapp.BasePresenter
 import com.codesquad_han.kotlin_drawingapp.BaseView
+import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 import com.codesquad_han.kotlin_drawingapp.model.RectangleImageviewData
 
 interface RectangleContract {
 
     interface View : BaseView<Presenter> {
-        fun showRectangle(width:Int, height: Int, x:Int, y:Int, colorStr: String)   // 사각형 정보 받아와서 이미지뷰 만들기
+        fun showRectangle(updatedRectangleList : MutableList<Rectangle>)   // 추가된 사각형을 포함한 리스트 받아와서 새로 그리기
 
-        fun showSelectedRectangle(rectangleList : ArrayList<RectangleImageviewData>)
+        fun showSelectedRectangle()
     }
 
     interface Presenter : BasePresenter {
-        fun generateRectangle() // 사각형 생성
+        fun addRectangle() // 사각형 생성
 
-        fun saveImageView(imageView: ImageView) // 사각형 정보를 바탕으로 생성한 이미지뷰를 저장
-
-        fun selectRectangleImageView(imageView: ImageView)
-
-        fun getRectangleImageViewList(rectangleList : ArrayList<RectangleImageviewData>)
+        fun getRectangleList()
     }
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
@@ -1,6 +1,7 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
 import android.widget.ImageView
+import androidx.lifecycle.MutableLiveData
 import com.codesquad_han.kotlin_drawingapp.BasePresenter
 import com.codesquad_han.kotlin_drawingapp.BaseView
 import com.codesquad_han.kotlin_drawingapp.model.Rectangle
@@ -13,6 +14,8 @@ interface RectangleContract {
     }
 
     interface Presenter : BasePresenter {
+        var liveRectangleList : MutableLiveData<MutableList<Rectangle>>
+
         fun addRectangle() // 사각형 생성
 
         fun getRectangleList()

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -1,0 +1,59 @@
+package com.codesquad_han.kotlin_drawingapp.rectangle
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.util.Log
+import android.view.MotionEvent
+import android.view.View
+import com.codesquad_han.kotlin_drawingapp.model.Rectangle
+
+class RectangleDrawingView @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private var selectedRectangle: Rectangle? = null
+    private var rectangleList = mutableListOf<Rectangle>()
+
+    private var paint = Paint()
+
+    override fun onDraw(canvas: Canvas) {
+        rectangleList.forEach { rectangle ->
+            paint.setColor(
+                Color.argb(
+                    rectangle.transparency.transparency * 255 / 10,
+                    rectangle.backgroundColor.r,
+                    rectangle.backgroundColor.g,
+                    rectangle.backgroundColor.b
+                )
+            )
+            canvas.drawRect(
+                rectangle.point.x.toFloat(),
+                rectangle.point.y.toFloat(),
+                (rectangle.point.x + rectangle.size.width).toFloat(),
+                (rectangle.point.y + rectangle.size.height).toFloat(),
+                paint
+            )
+
+            Log.d("AppTest", "RectangleDrawingView/ ${rectangle.toString()}")
+        }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+
+        // 클릭 리스너 사용해서 액티비티 연결하기
+
+        return true
+    }
+
+    fun drawRectangle(updatedRectangleList : MutableList<Rectangle>){
+        rectangleList = updatedRectangleList
+        invalidate()
+    }
+
+
+
+
+}

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -81,11 +81,13 @@ class RectangleDrawingView @JvmOverloads constructor(
         strokePaint.color = ContextCompat.getColor(context, R.color.selected)
     }
 
+    // 사각형 추가 혹은 선택된 사각형 투명도 변경 시 호출
     fun drawRectangle(updatedRectangleList: MutableList<Rectangle>) {
         rectangleList = updatedRectangleList
         invalidate()
     }
 
+    // 선택 좌표에 사각형이 여러 개 있는 경우 가장 최근에 생성된 사각형을 선택
     fun checkTouchPoint(touchX: Float, touchY: Float) {
         var selected = false
         for (i in rectangleList.size - 1 downTo 0) {

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -4,10 +4,13 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.PointF
 import android.util.AttributeSet
 import android.util.Log
 import android.view.MotionEvent
 import android.view.View
+import androidx.core.content.ContextCompat
+import com.codesquad_han.kotlin_drawingapp.R
 import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 
 class RectangleDrawingView @JvmOverloads constructor(
@@ -18,6 +21,12 @@ class RectangleDrawingView @JvmOverloads constructor(
     private var rectangleList = mutableListOf<Rectangle>()
 
     private var paint = Paint()
+    private var strokePaint = Paint()
+    private lateinit var clickListener: RectangleViewClickInterface
+
+    fun setClickListener(listener: RectangleViewClickInterface) {
+        this.clickListener = listener
+    }
 
     override fun onDraw(canvas: Canvas) {
         rectangleList.forEach { rectangle ->
@@ -37,23 +46,66 @@ class RectangleDrawingView @JvmOverloads constructor(
                 paint
             )
 
+            selectedRectangle?.let {
+                if (rectangle.id == it.id) {
+                    canvas.drawRect(
+                        rectangle.point.x.toFloat(),
+                        rectangle.point.y.toFloat(),
+                        (rectangle.point.x + rectangle.size.width).toFloat(),
+                        (rectangle.point.y + rectangle.size.height).toFloat(),
+                        strokePaint
+                    )
+                }
+            }
+
             Log.d("AppTest", "RectangleDrawingView/ ${rectangle.toString()}")
         }
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
+        val currentPoint = PointF(event.x, event.y)
 
         // 클릭 리스너 사용해서 액티비티 연결하기
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> {
+                checkTouchPoint(currentPoint.x, currentPoint.y)
+            }
+        }
 
         return true
     }
 
-    fun drawRectangle(updatedRectangleList : MutableList<Rectangle>){
+    fun drawingViewInit() {
+        strokePaint.strokeWidth = 10f
+        strokePaint.style = Paint.Style.STROKE
+        strokePaint.color = ContextCompat.getColor(context, R.color.selected)
+    }
+
+    fun drawRectangle(updatedRectangleList: MutableList<Rectangle>) {
         rectangleList = updatedRectangleList
         invalidate()
     }
 
+    fun checkTouchPoint(touchX: Float, touchY: Float) {
+        var selected = false
+        for (i in rectangleList.size - 1 downTo 0) {
+            if (touchX >= rectangleList[i].point.x
+                && touchX <= rectangleList[i].point.x + rectangleList[i].size.width
+                && touchY >= rectangleList[i].point.y
+                && touchY <= rectangleList[i].point.y + rectangleList[i].size.height
+            ) {
+                selectedRectangle = rectangleList[i]
+                selected = true
+                break
+            }
+        }
 
+        if(!selected){
+            selectedRectangle = null
+        }
+
+        invalidate()
+    }
 
 
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -96,16 +96,33 @@ class RectangleDrawingView @JvmOverloads constructor(
             ) {
                 selectedRectangle = rectangleList[i]
                 selected = true
+
+                selectedRectangle?.let { // 액티비티에서 선택한 사각형 색상, 투명도 나타내기
+                    clickListener.clickDrawingView(getColorStr(it), it.transparency.transparency, true, it.id)
+                }
                 break
             }
         }
 
         if(!selected){
             selectedRectangle = null
+            clickListener.clickDrawingView("", -1, false, "")
         }
 
         invalidate()
     }
 
+    fun getColorStr(selectedRectangle: Rectangle): String{
+        var red = Integer.toHexString(selectedRectangle.backgroundColor.r)
+        var green = Integer.toHexString(selectedRectangle.backgroundColor.g)
+        var blue = Integer.toHexString(selectedRectangle.backgroundColor.b)
+
+        if(red.length == 1) red = "0" + red
+        if(green.length == 1) green = "0" + green
+        if(blue.length == 1) blue = "0" + blue
+
+        Log.d("AppTest", "selected rectangle color : #${red}${green}${blue}")
+        return "#${red}${green}${blue}"
+    }
 
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
@@ -1,10 +1,11 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
-import android.util.Log
 import com.codesquad_han.kotlin_drawingapp.data.RectangleRepository
-import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 
-class RectanglePresenter(val rectangleRepository: RectangleRepository, val rectangleView: RectangleContract.View) :
+class RectanglePresenter(
+    val rectangleRepository: RectangleRepository,
+    val rectangleView: RectangleContract.View
+) :
     RectangleContract.Presenter {
 
     init {
@@ -19,38 +20,13 @@ class RectanglePresenter(val rectangleRepository: RectangleRepository, val recta
         rectangleRepository.addRectangle()
     }
 
-    override fun getRectangleList(){ // 사각형 추가한 리스트 전달
+    override fun getRectangleList() { // 사각형 추가, 투명도 갱신한 리스트 전달
         rectangleView.showRectangle(rectangleRepository.getRectangleList())
     }
 
-    fun getColorString(alpha: Int, r: Int, g: Int, b: Int): String {  // 수정하기 형식에 안맞게 나오는 경우도 존재!!
-        var alphaStr = ""
-        when(alpha){ // 투명도 범위 10개로 나눔
-            0 -> alphaStr = "00"
-            1 -> alphaStr = "1A"
-            2 -> alphaStr = "33"
-            3 -> alphaStr = "4D"
-            4 -> alphaStr = "66"
-            5 -> alphaStr = "80"
-            6 -> alphaStr = "99"
-            7 -> alphaStr = "B3"
-            8 -> alphaStr = "CC"
-            9 -> alphaStr = "E6"
-            10 -> alphaStr = "FF"
-        }
-
-        var red = Integer.toHexString(r)
-        var green = Integer.toHexString(g)
-        var blue = Integer.toHexString(b)
-
-        if(red.length == 1) red = "0" + red
-        if(green.length == 1) green = "0" + green
-        if(blue.length == 1) blue = "0" + blue
-
-        Log.d("AppTest", "${alphaStr}${red}${green}${blue}")
-        return "${alphaStr}${red}${green}${blue}"
+    override fun updateTransparency(id: String, transparency: Int) {
+        rectangleRepository.updateTransparency(id, transparency)
     }
-
 
 
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
@@ -1,12 +1,16 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
+import androidx.lifecycle.MutableLiveData
 import com.codesquad_han.kotlin_drawingapp.data.RectangleRepository
+import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 
 class RectanglePresenter(
     val rectangleRepository: RectangleRepository,
     val rectangleView: RectangleContract.View
 ) :
     RectangleContract.Presenter {
+
+    override var liveRectangleList = MutableLiveData<MutableList<Rectangle>>()
 
     init {
         rectangleView.presenter = this
@@ -16,17 +20,19 @@ class RectanglePresenter(
         addRectangle()
     }
 
-    override fun addRectangle() {  // 사각형 추가만 하기
+    override fun addRectangle() {  // 사각형 추가 후 라이브데이터 갱신
         rectangleRepository.addRectangle()
+        liveRectangleList.value = rectangleRepository.getRectangleList()
     }
 
-    override fun getRectangleList() { // 사각형 추가, 투명도 갱신한 리스트 전달
+    override fun updateTransparency(id: String, transparency: Int) { // 선택된 사각형 투명도 데이터 변경 후 라이브데이터 갱신
+        rectangleRepository.updateTransparency(id, transparency)
+        liveRectangleList.value = rectangleRepository.getRectangleList()
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    override fun getRectangleList() { // 사각형 추가, 투명도 갱신한 리스트 전달, 라이브데이터 도입 전에 변화된 사각형 리스트를 가져오기 위한 함수
         rectangleView.showRectangle(rectangleRepository.getRectangleList())
     }
-
-    override fun updateTransparency(id: String, transparency: Int) {
-        rectangleRepository.updateTransparency(id, transparency)
-    }
-
-
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
@@ -1,11 +1,10 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
 import android.util.Log
-import android.widget.ImageView
-import com.codesquad_han.kotlin_drawingapp.model.Plane
-import com.codesquad_han.kotlin_drawingapp.model.RectangleImageviewData
+import com.codesquad_han.kotlin_drawingapp.data.RectangleRepository
+import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 
-class RectanglePresenter(val plane: Plane, val rectangleView: RectangleContract.View) :
+class RectanglePresenter(val rectangleRepository: RectangleRepository, val rectangleView: RectangleContract.View) :
     RectangleContract.Presenter {
 
     init {
@@ -13,24 +12,15 @@ class RectanglePresenter(val plane: Plane, val rectangleView: RectangleContract.
     }
 
     override fun start() {
-        generateRectangle()
+        addRectangle()
     }
 
-    override fun generateRectangle() {
-        val rectangle = plane.generateRectangle()
+    override fun addRectangle() {  // 사각형 추가만 하기
+        rectangleRepository.addRectangle()
+    }
 
-        val red = rectangle.getBackgroundColor().r
-        val green = rectangle.getBackgroundColor().g
-        val blue = rectangle.getBackgroundColor().b
-        val transparency = rectangle.getTransparency().transparency
-
-        rectangleView.showRectangle(
-            rectangle.getSize().width,
-            rectangle.getSize().height,
-            rectangle.getPoint().x,
-            rectangle.getPoint().y,
-            getColorString(transparency, red, green, blue)
-        )
+    override fun getRectangleList(){ // 사각형 추가한 리스트 전달
+        rectangleView.showRectangle(rectangleRepository.getRectangleList())
     }
 
     fun getColorString(alpha: Int, r: Int, g: Int, b: Int): String {  // 수정하기 형식에 안맞게 나오는 경우도 존재!!
@@ -61,16 +51,6 @@ class RectanglePresenter(val plane: Plane, val rectangleView: RectangleContract.
         return "${alphaStr}${red}${green}${blue}"
     }
 
-    override fun saveImageView(imageView: ImageView) {
-        plane.saveImageView(imageView)
-    }
 
-    override fun selectRectangleImageView(imageView: ImageView) {
-        getRectangleImageViewList(plane.selectImageView(imageView))
-    }
-
-    override fun getRectangleImageViewList(rectangleList: ArrayList<RectangleImageviewData>) {
-        rectangleView.showSelectedRectangle(rectangleList)
-    }
 
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleViewClickInterface.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleViewClickInterface.kt
@@ -1,5 +1,5 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
 interface RectangleViewClickInterface {
-    fun clickDrawingView()
+    fun clickDrawingView(color: String, alpha: Int, selected: Boolean, id: String)
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleViewClickInterface.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleViewClickInterface.kt
@@ -1,0 +1,5 @@
+package com.codesquad_han.kotlin_drawingapp.rectangle
+
+interface RectangleViewClickInterface {
+    fun clickDrawingView()
+}

--- a/app/src/main/res/layout-sw600dp/activity_rectangle.xml
+++ b/app/src/main/res/layout-sw600dp/activity_rectangle.xml
@@ -124,7 +124,19 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <Button
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnOpenGallery"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintWidth_percent="0.8"
+            app:layout_constraintBottom_toTopOf="@id/btnGenerateRectangle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:backgroundTint="@color/teal_200"
+            android:text="사진 가져오기"
+            android:enabled="false"/>
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btnGenerateRectangle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout-sw600dp/activity_rectangle.xml
+++ b/app/src/main/res/layout-sw600dp/activity_rectangle.xml
@@ -33,7 +33,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_percent="0.4"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            android:visibility="invisible">
 
             <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/gl_v_8"

--- a/app/src/main/res/layout-sw600dp/activity_rectangle.xml
+++ b/app/src/main/res/layout-sw600dp/activity_rectangle.xml
@@ -7,17 +7,14 @@
     android:layout_height="match_parent"
     tools:context=".rectangle.RectangleActivity">
 
-    <FrameLayout
-        android:id="@+id/frameLayoutDraw"
+    <com.codesquad_han.kotlin_drawingapp.rectangle.RectangleDrawingView
+        android:id="@+id/rectangleDrawingView"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.75">
-
-
-    </FrameLayout>
+        app:layout_constraintWidth_percent="0.75"/>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/constraintLayoutRightSide"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="selected">#3DE5F4</color>
 </resources>


### PR DESCRIPTION
- 기존의 이미지 뷰로 구현했던 코드에서 커스텀 뷰를 사용하는 방법으로 전면 수정했습니다

- MVP에 패턴에 repository를 추가하여 필요한 데이터를 저장 및 가져오도록 구현했습니다

- Material Design 의 Slider를 사용하여 투명도 조절을 구현했습니다
***

Q1. 아래와 같이 제가 구현한 내용이 알맞은 흐름인지 궁금합니다!!!
Plane 에서는 사각형 모델의 리스트를 가지고 있고, Presenter에서는 livedata 형태로 사각형 모델의 리스트를 가지고 있습니다.
사각형이 추가되거나 투명도 재설정으로 Plane의 사각형 리스트가 변경되면 Presenter 의 livedata 에 동일하게 변경된 리스트 값을 할당합니다.
이 과정에서 Activity에서는 Presenter의 livedata(사각형 리스트)를 observe 하고 있었고, 변화를 감지하여 자동으로 변화된 리스트를 사용하여 커스텀뷰에서 사각형을 새로 그리게 구현했습니다.