### PR TITLE
[히데]  드래그 기능/  권한 설정  수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # kotlin-drawingapp
-- 요구사항 파악
-- 구현 완료 후 자신의 github 아이디에 해당하는 브랜치에 PR을 통해 코드 리뷰 요청
-- 코드 리뷰 피드백에 대한 개선 작업 후 push
-- 모든 피드백 완료 후 다음 단계를 도전하고 이전 과정 반복
+## 권한 설정 테스트
+* 허용클릭시
+![allow](https://user-images.githubusercontent.com/58967292/157374059-7a13ba50-74a9-43d1-ad12-4ec1f107b7da.gif)
+
+* 비허용 클릭시 -> 안내 메시지 출력 -> 앱설정화면 이동기능 
+![dont allow](https://user-images.githubusercontent.com/58967292/157374064-7872de4a-bff8-483a-b891-cd4f2c78652f.gif)
+
+* 드래그 테스트
+![drag test](https://user-images.githubusercontent.com/58967292/157374128-707f157c-e57a-4c68-9cb4-883fda11c962.gif)

--- a/app/src/main/java/model/Plane.kt
+++ b/app/src/main/java/model/Plane.kt
@@ -68,6 +68,14 @@ class Plane(private val context: Context) {
 
     }
 
+    fun changePosition(rectId: String, x:Int, y:Int):Rect?{
+        val selectedRect =   customRectangleList.find {  it.rectId == rectId  }
+
+        selectedRect?.point?.xPos = x
+        selectedRect?.point?.yPos= y
+        return selectedRect
+    }
+
 
 
 

--- a/app/src/main/java/model/Point.kt
+++ b/app/src/main/java/model/Point.kt
@@ -1,6 +1,6 @@
 package model
 
-data class Point(val xPos: Int, val yPos: Int) {
+data class Point(var xPos: Int, var yPos: Int) {
     override fun toString(): String {
         return "X:$xPos,Y:$yPos,"
     }

--- a/app/src/main/java/presenter/MainPresenter.kt
+++ b/app/src/main/java/presenter/MainPresenter.kt
@@ -1,5 +1,6 @@
 import android.content.Context
 import android.graphics.Bitmap
+import model.Photo
 import model.Plane
 import view.MainContract
 import view.RectView
@@ -28,7 +29,12 @@ class MainPresenter(
 
     override fun changePosition(rectView: RectView) {
         plane.changePosition(rectView.rectId, rectView.left.toInt(), rectView.top.toInt())?.let{
-            view.redrawRectangle(it)
+            if(rectView.photoId=="") {
+                view.redrawRectangle(it)
+            }
+            else{
+                view.redrawPhoto(it as Photo)
+            }
         }
     }
 

--- a/app/src/main/java/presenter/MainPresenter.kt
+++ b/app/src/main/java/presenter/MainPresenter.kt
@@ -26,6 +26,12 @@ class MainPresenter(
         plane.changeOpacity(rectView.rectId, opacity)
     }
 
+    override fun changePosition(rectView: RectView) {
+        plane.changePosition(rectView.rectId, rectView.left.toInt(), rectView.top.toInt())?.let{
+            view.redrawRectangle(it)
+        }
+    }
+
     override fun createRectanglePaint() {
         view.drawRectangle(plane.createRectanglePaint())
     }

--- a/app/src/main/java/view/MainActivity.kt
+++ b/app/src/main/java/view/MainActivity.kt
@@ -245,5 +245,17 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         customRectangleViewList.add(rectView)
     }
 
+    override fun redrawPhoto(photo: Photo) {
+        mainLayout.removeView(selectedCustomRectangleView)
+        customRectangleViewList.remove(selectedCustomRectangleView)
+        val rectView = RectView(this)
+        selectedCustomRectangleView?.bitmap?.let{
+            rectView.drawPhoto(it,photo)
+        }
+        selectedCustomRectangleView = rectView
+        mainLayout.addView(rectView)
+        customRectangleViewList.add(rectView)
+    }
+
 }
 

--- a/app/src/main/java/view/MainContract.kt
+++ b/app/src/main/java/view/MainContract.kt
@@ -11,6 +11,7 @@ interface MainContract {
         fun drawRectangle(rect:Rect)
         fun drawPhoto(photo: Photo)
         fun redrawRectangle(rect:Rect)
+        fun redrawPhoto(photo: Photo)
     }
 
     interface Presenter {

--- a/app/src/main/java/view/MainContract.kt
+++ b/app/src/main/java/view/MainContract.kt
@@ -10,12 +10,14 @@ interface MainContract {
         fun displaySelectedRectAttribute(rect:Rect)
         fun drawRectangle(rect:Rect)
         fun drawPhoto(photo: Photo)
+        fun redrawRectangle(rect:Rect)
     }
 
     interface Presenter {
         fun selectRectangle(xPos: Float, yPos: Float)
         fun changeColor(rectView: RectView)
         fun changeOpacity(rectView: RectView, opacity: Int)
+        fun changePosition(rectView: RectView)
         fun createRectanglePaint()
         fun createPhotoPaint(image: Bitmap)
     }

--- a/app/src/main/java/view/RectView.kt
+++ b/app/src/main/java/view/RectView.kt
@@ -133,20 +133,9 @@ class RectView(context: Context) : View(context) {
         invalidate()
     }
 
-    fun onTouch(event: MotionEvent): RectView {
+    fun onTouch(event: MotionEvent,tempView:RectView) {
         val x: Float
         val y: Float
-        var tempView = RectView(context)
-        tempView.rectId = "temp"
-        if(this.photoId==""){
-            tempView.rectanglePaint.color = this.rectanglePaint.color
-        }
-        else{
-            tempView.photoId= "tempPhoto"
-            tempView.bitmap = this.bitmap
-        }
-
-        tempView.alpha = (5 * 25.5).toInt()
         when (event.action) {
             MotionEvent.ACTION_MOVE -> {
                 x = event.getX(0)
@@ -155,7 +144,6 @@ class RectView(context: Context) : View(context) {
                 tempView.top = y
                 tempView.right = (x + this.rectWidth)
                 tempView.bottom = y + this.rectHeight
-                return tempView
             }
             MotionEvent.ACTION_UP -> {
                 x = event.getX(0)
@@ -164,10 +152,8 @@ class RectView(context: Context) : View(context) {
                 this.top = y
                 this.right = x + this.rectWidth
                 this.bottom = y + this.rectHeight
-                return this
             }
         }
-        return this
     }
 
 

--- a/app/src/main/java/view/RectView.kt
+++ b/app/src/main/java/view/RectView.kt
@@ -13,7 +13,7 @@ import model.Rect
 
 
 class RectView(context: Context) : View(context) {
-    private var bitmap: Bitmap? = null
+    var bitmap: Bitmap? = null
     var rectId = ""
     var photoId = ""
     var left = 0.0F
@@ -138,7 +138,14 @@ class RectView(context: Context) : View(context) {
         val y: Float
         var tempView = RectView(context)
         tempView.rectId = "temp"
-        tempView.rectanglePaint.color = this.rectanglePaint.color
+        if(this.photoId==""){
+            tempView.rectanglePaint.color = this.rectanglePaint.color
+        }
+        else{
+            tempView.photoId= "tempPhoto"
+            tempView.bitmap = this.bitmap
+        }
+
         tempView.alpha = (5 * 25.5).toInt()
         when (event.action) {
             MotionEvent.ACTION_MOVE -> {

--- a/app/src/main/java/view/RectView.kt
+++ b/app/src/main/java/view/RectView.kt
@@ -1,7 +1,11 @@
 package view
 
 import android.content.Context
-import android.graphics.*
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.view.MotionEvent
 import android.view.View
 import model.BackGroundColor
 import model.Photo
@@ -12,14 +16,16 @@ class RectView(context: Context) : View(context) {
     private var bitmap: Bitmap? = null
     var rectId = ""
     var photoId = ""
-    private var left = 0.0F
+    var left = 0.0F
     private var right = 0.0F
-    private var top = 0.0F
+    var top = 0.0F
     private var bottom = 0.0F
+    var rectWidth = 0
+    var rectHeight = 0
     var alpha = 0
-    var backGroundRGB:String=""
-    private var selectedFlag = false
-    private val rectanglePaint = Paint()
+    var backGroundRGB: String = ""
+    var selectedFlag = false
+    var rectanglePaint = Paint()
     private val borderPaint = Paint().apply {
         this.style = Paint.Style.STROKE
         this.color = Color.BLACK
@@ -49,8 +55,10 @@ class RectView(context: Context) : View(context) {
             left = it.point.xPos.toFloat()
             right = (it.point.xPos + it.size.width).toFloat()
             top = it.point.yPos.toFloat()
+            this.rectWidth = it.size.width
+            this.rectHeight = it.size.height
             bottom = (it.point.yPos + it.size.height).toFloat()
-            this.backGroundRGB= it.backGroundColor.value?.getRGBHexValue().toString()
+            this.backGroundRGB = it.backGroundColor.value?.getRGBHexValue().toString()
             val backGroundColor = it.backGroundColor.value?.getBackGroundColor()
             val opacity = ((it.opacity.value?.times(25.5))?.toInt())
             backGroundColor?.let { color ->
@@ -65,7 +73,7 @@ class RectView(context: Context) : View(context) {
 
     fun drawPhoto(image: Bitmap, photo: Photo) {
         photo.let {
-            rectId= photo.rectId
+            rectId = photo.rectId
             photoId = photo.photoId
             left = it.point.xPos.toFloat()
             right = (it.point.xPos + it.size.width).toFloat()
@@ -75,7 +83,7 @@ class RectView(context: Context) : View(context) {
                 this.alpha = (alpha * 25.5).toInt()
             }
         }
-        this.backGroundRGB ="No Color"
+        this.backGroundRGB = "No Color"
         this.bitmap = resizeBitmap(image, photo)
     }
 
@@ -124,5 +132,36 @@ class RectView(context: Context) : View(context) {
         this.alpha = (opacity * 25.5).toInt()
         invalidate()
     }
+
+    fun onTouch(event: MotionEvent): RectView {
+        val x: Float
+        val y: Float
+        var tempView = RectView(context)
+        tempView.rectId = "temp"
+        tempView.rectanglePaint.color = this.rectanglePaint.color
+        tempView.alpha = (5 * 25.5).toInt()
+        when (event.action) {
+            MotionEvent.ACTION_MOVE -> {
+                x = event.getX(0)
+                y = event.getY(0)
+                tempView.left = x
+                tempView.top = y
+                tempView.right = (x + this.rectWidth)
+                tempView.bottom = y + this.rectHeight
+                return tempView
+            }
+            MotionEvent.ACTION_UP -> {
+                x = event.getX(0)
+                y = event.getY(0)
+                this.left = x
+                this.top = y
+                this.right = x + this.rectWidth
+                this.bottom = y + this.rectHeight
+                return this
+            }
+        }
+        return this
+    }
+
 
 }

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -2,17 +2,97 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_layout_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="view.MainActivity">
 
-    <TextView
+    <FrameLayout
+        android:id="@+id/image_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:layout_editor_absoluteX="-421dp"
+        tools:layout_editor_absoluteY="16dp" />
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:background="@color/sideBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_rgb_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="50dp"
+            android:layout_marginTop="50dp"
+            android:layout_marginRight="50dp"
+            android:text="배경색"
+            android:textColor="@color/black"
+            />
+
+        <TextView
+            android:id="@+id/tv_rgb_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv_rgb_title"
+            android:layout_marginLeft="32dp"
+            android:layout_marginTop="15dp"
+            android:background="@drawable/imageview_border"
+            android:padding="10dp"
+            android:text="#000000"
+            android:textSize="15sp" />
+
+        <TextView
+            android:id="@+id/tv_alpha_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv_rgb_value"
+            android:layout_marginLeft="50dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginRight="50dp"
+            android:text="투명도"
+            android:textColor="@color/black" />
+
+        <SeekBar
+            android:id="@+id/seekbar_opacity"
+            android:layout_width="140dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv_alpha_title"
+            android:layout_marginLeft="10dp"
+            android:layout_marginTop="15dp"
+            android:max="10"
+            android:layout_marginRight="10dp" />
+
+    </RelativeLayout>
+
+    <Button
+        android:id="@+id/btn_addRectangle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
+        android:background="@color/white"
+        android:paddingTop="30dp"
+        android:paddingBottom="10dp"
+        android:text="⬜\n사각형"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="15sp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+    <Button
+        android:id="@+id/btn_addPhoto"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:paddingTop="30dp"
+        android:paddingBottom="10dp"
+        android:text="⬜\n사진"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toBottomOf="parent"
 
+        app:layout_constraintStart_toEndOf="@id/btn_addRectangle" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,17 +2,97 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_layout_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="view.MainActivity">
 
-    <TextView
+    <FrameLayout
+        android:id="@+id/image_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:layout_editor_absoluteX="-421dp"
+        tools:layout_editor_absoluteY="16dp" />
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:background="@color/sideBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_rgb_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="50dp"
+            android:layout_marginTop="50dp"
+            android:layout_marginRight="50dp"
+            android:text="배경색"
+            android:textColor="@color/black"
+            />
+
+        <TextView
+            android:id="@+id/tv_rgb_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv_rgb_title"
+            android:layout_marginLeft="32dp"
+            android:layout_marginTop="15dp"
+            android:background="@drawable/imageview_border"
+            android:padding="10dp"
+            android:text="#000000"
+            android:textSize="15sp" />
+
+        <TextView
+            android:id="@+id/tv_alpha_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv_rgb_value"
+            android:layout_marginLeft="50dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginRight="50dp"
+            android:text="투명도"
+            android:textColor="@color/black" />
+
+        <SeekBar
+            android:id="@+id/seekbar_opacity"
+            android:layout_width="140dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv_alpha_title"
+            android:layout_marginLeft="10dp"
+            android:layout_marginTop="15dp"
+            android:max="10"
+            android:layout_marginRight="10dp" />
+
+    </RelativeLayout>
+
+    <Button
+        android:id="@+id/btn_addRectangle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
+        android:background="@color/white"
+        android:paddingTop="30dp"
+        android:paddingBottom="10dp"
+        android:text="⬜\n사각형"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="15sp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+    <Button
+        android:id="@+id/btn_addPhoto"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:paddingTop="30dp"
+        android:paddingBottom="10dp"
+        android:text="⬜\n사진"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toBottomOf="parent"
 
+        app:layout_constraintStart_toEndOf="@id/btn_addRectangle" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
* 드래그 기능
  * 가상 에뮬레이터로 두 손가락 터치를 테스트 할 수 없어 우선 한 손가락 터치로 드래그를 구현했습니다
  * ACTION_MOVE 이벤트처리에서 tempView 객체를 생성해 반환하는 식으로 임시뷰 구현
  * ACTION_UP 이벤트에서 원래 사각형을 지우고 새로운 자리에 사각형 그리기로 구현  
  * 현재 사진과 사각형에 대해 다시 그리는 작업이 분리되어 있어서  수정예정입니다. 

* 권한 설정
  * 기존 구현에는 한 번 권한설정을 거절하면  사용자가 수동으로 바꿔주지 않으면 기능이 실행되지 않음
  * 수정 구현에는 한 번 권한 설정 거절시,  안내 메시지 출력과 앱 설정화면으로 이동할 수 있는 alertDialog 추가

* Layout XML 파일추가
  * 일반 휴대폰 기기에서도 앱 구동을 확인할수 있게 추가