### PR TITLE
[Han] 투명도 slider->seekbar, 태블릿 외 레이아웃 대응, 드래그 앤 드롭 구현(멀티터치) 

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <runningDeviceTargetSelectedWithDropDown>
+    <targetSelectedWithDropDown>
       <Target>
-        <type value="RUNNING_DEVICE_TARGET" />
+        <type value="QUICK_BOOT_TARGET" />
         <deviceKey>
           <Key>
-            <type value="SERIAL_NUMBER" />
-            <value value="2169d28b10047ece" />
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\Win10\.android\avd\Pixel_C_API_31_3.avd" />
           </Key>
         </deviceKey>
       </Target>
-    </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-03-09T09:16:37.137628Z" />
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-03-10T16:30:41.507263200Z" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\Win10\.android\avd\Pixel_C_API_31_3.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="2169d28b10047ece" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-03-07T13:03:55.928140600Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-03-09T09:16:37.137628Z" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-03-03T17:53:20.335030800Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-03-07T08:35:19.609053100Z" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-03-07T08:35:19.609053100Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-03-07T13:03:55.928140600Z" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/drawable/textview_background_1.xml" value="0.2135" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-land/activity_main.xml" value="0.16510416666666666" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_main.xml" value="0.22" />
-        <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_rectangle.xml" value="0.5" />
+        <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_rectangle.xml" value="0.25" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout/activity_main.xml" value="0.25" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout/activity_rectangle.xml" value="0.28958333333333336" />
       </map>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/drawable/textview_background_1.xml" value="0.2135" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-land/activity_main.xml" value="0.16510416666666666" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_main.xml" value="0.22" />
-        <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_rectangle.xml" value="0.25" />
+        <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout-sw600dp/activity_rectangle.xml" value="0.5" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout/activity_main.xml" value="0.25" />
         <entry key="..\:/Users/Win10/Desktop/changhee/CodeSquadAndroidClass/mission03/kotlin-drawingapp/app/src/main/res/layout/activity_rectangle.xml" value="0.28958333333333336" />
       </map>

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepository.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepository.kt
@@ -12,4 +12,6 @@ interface RectangleRepository {
     fun updateTransparency(id: String, transparency: Int)
 
     fun updateImageUri(id: String, imageUri: Uri?)
+
+    fun updateSelctedRectanglePoint(id: String, newX: Int, newY: Int)
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepository.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepository.kt
@@ -1,5 +1,6 @@
 package com.codesquad_han.kotlin_drawingapp.data
 
+import android.net.Uri
 import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 
 interface RectangleRepository {
@@ -9,4 +10,6 @@ interface RectangleRepository {
     fun getRectangleList() : MutableList<Rectangle>
 
     fun updateTransparency(id: String, transparency: Int)
+
+    fun updateImageUri(id: String, imageUri: Uri?)
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepositoryImpl.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepositoryImpl.kt
@@ -18,4 +18,8 @@ class RectangleRepositoryImpl(var plane: Plane) : RectangleRepository {
     override fun updateImageUri(id: String, imageUri: Uri?) {
         plane.updateImageUri(id, imageUri)
     }
+
+    override fun updateSelctedRectanglePoint(id: String, newX: Int, newY: Int) {
+        plane.updateSelectedRectanglePoint(id, newX, newY)
+    }
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepositoryImpl.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/data/RectangleRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.codesquad_han.kotlin_drawingapp.data
 
+import android.net.Uri
 import com.codesquad_han.kotlin_drawingapp.model.Plane
 import com.codesquad_han.kotlin_drawingapp.model.Rectangle
 
@@ -12,5 +13,9 @@ class RectangleRepositoryImpl(var plane: Plane) : RectangleRepository {
 
     override fun updateTransparency(id: String, transparency: Int) {
         plane.updateTransparency(id, transparency)
+    }
+
+    override fun updateImageUri(id: String, imageUri: Uri?) {
+        plane.updateImageUri(id, imageUri)
     }
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Plane.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Plane.kt
@@ -1,5 +1,7 @@
 package com.codesquad_han.kotlin_drawingapp.model
 
+import android.net.Uri
+
 class Plane(rectangleFactory: RectangleFactory) {
     private var rectangleList = mutableListOf<Rectangle>()
     private var rectangleFactory = rectangleFactory
@@ -15,6 +17,14 @@ class Plane(rectangleFactory: RectangleFactory) {
         rectangleList.forEach {
             if (it.id == id) {
                 it.transparency.transparency = transparency
+            }
+        }
+    }
+
+    fun updateImageUri(id: String, imageUri: Uri?) {
+        rectangleList.forEach {
+            if(it.id == id){
+                it.imageUri = imageUri
             }
         }
     }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Plane.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Plane.kt
@@ -21,6 +21,15 @@ class Plane(rectangleFactory: RectangleFactory) {
         }
     }
 
+    fun updateSelectedRectanglePoint(id: String, newX: Int, newY: Int){
+        rectangleList.forEach {
+            if (it.id == id) {
+                it.point.x = newX
+                it.point.y = newY
+            }
+        }
+    }
+
     fun updateImageUri(id: String, imageUri: Uri?) {
         rectangleList.forEach {
             if(it.id == id){

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Rectangle.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/Rectangle.kt
@@ -1,21 +1,26 @@
 package com.codesquad_han.kotlin_drawingapp.model
 
+import android.net.Uri
+
+
 class Rectangle(
     id: String,
     point: Point,
     size: Size,
     backgroundColor: BackgroundColor,
-    transparency: Transparency
+    transparency: Transparency,
+    imageUri: Uri?
 ) {
     val id = id
     val point = point
     val size = size
     val backgroundColor = backgroundColor
     val transparency = transparency
+    var imageUri = imageUri
 
     override fun toString(): String {
         return "($id), X:${point.x},Y:${point.y}, W:${size.width},H:${size.height}, R:${backgroundColor.r},G:${backgroundColor.g},${backgroundColor.b}, " +
-                "Alpha:${transparency.transparency}"
+                "Alpha:${transparency.transparency}, Image Uri : ${imageUri} ."
     }
 
 

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/RectangleFactory.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/model/RectangleFactory.kt
@@ -12,7 +12,8 @@ class RectangleFactory(x: Int, y: Int) {
             Point((0..x).random(), (0..y).random()),
             Size(300, 240),  // Pixcel C API 31 에서 1dp = 2px, 따라서 2배해준 값 사용
             BackgroundColor((0..255).random(), (0..255).random(), (0..255).random()),
-            Transparency((1..10).random())
+            Transparency((1..10).random()),
+            null
         )
     }
 

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -124,6 +124,11 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
         }
     }
 
+    override fun updateSelectedRectanglePoint(id: String, newX: Int, newY: Int) {
+        SELECTED_RECTANGLE_ID = id
+        presenter.updateSelectedRectanglePoint(id, newX, newY)
+    }
+
     fun ConvertDPtoPX(context: Context, dp: Int): Int {
         val density = context.resources.displayMetrics.density
         return Math.round(dp.toFloat() * density)

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleActivity.kt
@@ -150,7 +150,7 @@ class RectangleActivity : AppCompatActivity(), RectangleContract.View, Rectangle
             if(it.resultCode == RESULT_OK){
                 Log.d("AppTest", "RectangleActivity/ data : ${it.data?.data}")
                 // uri 전달하기!!!!
-
+                presenter.updateImageUri(SELECTED_RECTANGLE_ID, it.data?.data)
             }
             else{
                 Snackbar.make(binding.root, "사진 불러오기 취소", Snackbar.LENGTH_SHORT).show()

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
@@ -15,7 +15,7 @@ interface RectangleContract {
     }
 
     interface Presenter : BasePresenter {
-        var liveRectangleList : MutableLiveData<MutableList<Rectangle>>
+        var liveRectangleList: MutableLiveData<MutableList<Rectangle>>
 
         fun addRectangle() // 사각형 생성
 
@@ -24,5 +24,7 @@ interface RectangleContract {
         fun updateTransparency(id: String, transparency: Int) // 선택한 사각형 투명도 변경
 
         fun updateImageUri(id: String, imageUri: Uri?) // 선택한 사각형 이미지 uri 업데이트
+
+        fun updateSelectedRectanglePoint(id: String, newX: Int, newY: Int) // 선택한 사각형 드래그 후 위치값 업데이트
     }
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleContract.kt
@@ -1,5 +1,6 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
+import android.net.Uri
 import android.widget.ImageView
 import androidx.lifecycle.MutableLiveData
 import com.codesquad_han.kotlin_drawingapp.BasePresenter
@@ -21,5 +22,7 @@ interface RectangleContract {
         fun getRectangleList()
 
         fun updateTransparency(id: String, transparency: Int) // 선택한 사각형 투명도 변경
+
+        fun updateImageUri(id: String, imageUri: Uri?) // 선택한 사각형 이미지 uri 업데이트
     }
 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -55,13 +55,16 @@ class RectangleDrawingView @JvmOverloads constructor(
                     val source = ImageDecoder.createSource(context.contentResolver, it)
                     bitmap = ImageDecoder.decodeBitmap(source)
                 }
+
+                var imagePaint = Paint()
+                imagePaint.alpha = rectangle.transparency.transparency * 255 / 10
                 canvas.drawBitmap(
                     bitmap, null, Rect(
                         rectangle.point.x,
                         rectangle.point.y,
                         (rectangle.point.x + rectangle.size.width),
                         (rectangle.point.y + rectangle.size.height)
-                    ), null
+                    ), imagePaint
                 )
             }
 

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -13,9 +13,12 @@ import com.codesquad_han.kotlin_drawingapp.R
 import com.codesquad_han.kotlin_drawingapp.model.*
 import com.codesquad_han.kotlin_drawingapp.model.Point
 
-class RectangleDrawingView @JvmOverloads constructor(
-    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
-) : View(context, attrs, defStyleAttr) {
+class RectangleDrawingView : View {
+
+    constructor(context: Context) : super(context, null)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs, 0)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
 
     private var selectedRectangle: Rectangle? = null
     private var tempRectangle: Rectangle? = null

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -1,10 +1,8 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Paint
-import android.graphics.PointF
+import android.graphics.*
+import android.provider.MediaStore
 import android.util.AttributeSet
 import android.util.Log
 import android.view.MotionEvent
@@ -45,6 +43,19 @@ class RectangleDrawingView @JvmOverloads constructor(
                 (rectangle.point.y + rectangle.size.height).toFloat(),
                 paint
             )
+
+            // 사각형에 할당된 이미지 uri가 있다면 그리도록 한다
+            rectangle.imageUri?.let {
+                var bitmap = MediaStore.Images.Media.getBitmap(context.contentResolver, it)
+                canvas.drawBitmap(
+                    bitmap, null, Rect(
+                        rectangle.point.x,
+                        rectangle.point.y,
+                        (rectangle.point.x + rectangle.size.width),
+                        (rectangle.point.y + rectangle.size.height)
+                    ), null
+                )
+            }
 
             selectedRectangle?.let {
                 if (rectangle.id == it.id) {
@@ -100,13 +111,18 @@ class RectangleDrawingView @JvmOverloads constructor(
                 selected = true
 
                 selectedRectangle?.let { // 액티비티에서 선택한 사각형 색상, 투명도 나타내기
-                    clickListener.clickDrawingView(getColorStr(it), it.transparency.transparency, true, it.id)
+                    clickListener.clickDrawingView(
+                        getColorStr(it),
+                        it.transparency.transparency,
+                        true,
+                        it.id
+                    )
                 }
                 break
             }
         }
 
-        if(!selected){
+        if (!selected) {
             selectedRectangle = null
             clickListener.clickDrawingView("", -1, false, "")
         }
@@ -114,14 +130,14 @@ class RectangleDrawingView @JvmOverloads constructor(
         invalidate()
     }
 
-    fun getColorStr(selectedRectangle: Rectangle): String{
+    fun getColorStr(selectedRectangle: Rectangle): String {
         var red = Integer.toHexString(selectedRectangle.backgroundColor.r)
         var green = Integer.toHexString(selectedRectangle.backgroundColor.g)
         var blue = Integer.toHexString(selectedRectangle.backgroundColor.b)
 
-        if(red.length == 1) red = "0" + red
-        if(green.length == 1) green = "0" + green
-        if(blue.length == 1) blue = "0" + blue
+        if (red.length == 1) red = "0" + red
+        if (green.length == 1) green = "0" + green
+        if (blue.length == 1) blue = "0" + blue
 
         Log.d("AppTest", "selected rectangle color : #${red}${green}${blue}")
         return "#${red}${green}${blue}"

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -37,21 +37,23 @@ class RectangleDrawingView @JvmOverloads constructor(
                     rectangle.backgroundColor.b
                 )
             )
-            canvas.drawRect(
-                rectangle.point.x.toFloat(),
-                rectangle.point.y.toFloat(),
-                (rectangle.point.x + rectangle.size.width).toFloat(),
-                (rectangle.point.y + rectangle.size.height).toFloat(),
-                paint
-            )
+
+            if (rectangle.imageUri == null) {
+                canvas.drawRect(
+                    rectangle.point.x.toFloat(),
+                    rectangle.point.y.toFloat(),
+                    (rectangle.point.x + rectangle.size.width).toFloat(),
+                    (rectangle.point.y + rectangle.size.height).toFloat(),
+                    paint
+                )
+            }
 
             // 사각형에 할당된 이미지 uri가 있다면 그리도록 한다
             rectangle.imageUri?.let {
-                var bitmap : Bitmap
-                if(Build.VERSION.SDK_INT < 29 ){ //
+                var bitmap: Bitmap
+                if (Build.VERSION.SDK_INT < 29) { //
                     bitmap = MediaStore.Images.Media.getBitmap(context.contentResolver, it)
-                }
-                else {
+                } else {
                     val source = ImageDecoder.createSource(context.contentResolver, it)
                     bitmap = ImageDecoder.decodeBitmap(source)
                 }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -2,6 +2,7 @@ package com.codesquad_han.kotlin_drawingapp.rectangle
 
 import android.content.Context
 import android.graphics.*
+import android.os.Build
 import android.provider.MediaStore
 import android.util.AttributeSet
 import android.util.Log
@@ -46,7 +47,14 @@ class RectangleDrawingView @JvmOverloads constructor(
 
             // 사각형에 할당된 이미지 uri가 있다면 그리도록 한다
             rectangle.imageUri?.let {
-                var bitmap = MediaStore.Images.Media.getBitmap(context.contentResolver, it)
+                var bitmap : Bitmap
+                if(Build.VERSION.SDK_INT < 29 ){ //
+                    bitmap = MediaStore.Images.Media.getBitmap(context.contentResolver, it)
+                }
+                else {
+                    val source = ImageDecoder.createSource(context.contentResolver, it)
+                    bitmap = ImageDecoder.decodeBitmap(source)
+                }
                 canvas.drawBitmap(
                     bitmap, null, Rect(
                         rectangle.point.x,

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleDrawingView.kt
@@ -171,11 +171,13 @@ class RectangleDrawingView @JvmOverloads constructor(
             }
             MotionEvent.ACTION_UP -> {
                 if (isDoubleTouchExist) {
-                    selectedRectangle!!.point.x = tempRectangle!!.point.x
-                    selectedRectangle!!.point.y = tempRectangle!!.point.y  // 임시 사각형 뷰로 선택 사각형 위치 이동
+                    var newX = tempRectangle!!.point.x
+                    var newY = tempRectangle!!.point.y
                     tempRectangle = null
                     isDoubleTouchExist = false
-                    invalidate()
+
+                     // 임시 사각형 뷰로 선택 사각형 위치 이동
+                    clickListener.updateSelectedRectanglePoint(selectedRectangle!!.id, newX, newY)
                 }
             }
         }

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
@@ -1,5 +1,6 @@
 package com.codesquad_han.kotlin_drawingapp.rectangle
 
+import android.net.Uri
 import androidx.lifecycle.MutableLiveData
 import com.codesquad_han.kotlin_drawingapp.data.RectangleRepository
 import com.codesquad_han.kotlin_drawingapp.model.Rectangle
@@ -27,6 +28,11 @@ class RectanglePresenter(
 
     override fun updateTransparency(id: String, transparency: Int) { // 선택된 사각형 투명도 데이터 변경 후 라이브데이터 갱신
         rectangleRepository.updateTransparency(id, transparency)
+        liveRectangleList.value = rectangleRepository.getRectangleList()
+    }
+
+    override fun updateImageUri(id: String, imageUri: Uri?) { // 선택한 사각형에 갤러리에서 선택한 이미지 삽입 시 데이터 변경 후 라이브데이터 갱신
+        rectangleRepository.updateImageUri(id, imageUri)
         liveRectangleList.value = rectangleRepository.getRectangleList()
     }
 

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectanglePresenter.kt
@@ -36,6 +36,11 @@ class RectanglePresenter(
         liveRectangleList.value = rectangleRepository.getRectangleList()
     }
 
+    override fun updateSelectedRectanglePoint(id: String, newX: Int, newY: Int) {
+        rectangleRepository.updateSelctedRectanglePoint(id, newX, newY)
+        liveRectangleList.value = rectangleRepository.getRectangleList()
+    }
+
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     override fun getRectangleList() { // 사각형 추가, 투명도 갱신한 리스트 전달, 라이브데이터 도입 전에 변화된 사각형 리스트를 가져오기 위한 함수

--- a/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleViewClickInterface.kt
+++ b/app/src/main/java/com/codesquad_han/kotlin_drawingapp/rectangle/RectangleViewClickInterface.kt
@@ -2,4 +2,6 @@ package com.codesquad_han.kotlin_drawingapp.rectangle
 
 interface RectangleViewClickInterface {
     fun clickDrawingView(color: String, alpha: Int, selected: Boolean, id: String)
+
+    fun updateSelectedRectanglePoint(id: String, newX : Int, newY : Int)
 }

--- a/app/src/main/res/layout-sw600dp/activity_rectangle.xml
+++ b/app/src/main/res/layout-sw600dp/activity_rectangle.xml
@@ -14,7 +14,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.75"/>
+        app:layout_constraintWidth_percent="0.75" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/constraintLayoutRightSide"
@@ -30,11 +30,11 @@
             android:id="@+id/constraintLayoutControl"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:visibility="visible"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_percent="0.4"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:visibility="invisible">
+            app:layout_constraintTop_toTopOf="parent">
 
             <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/gl_v_8"
@@ -55,8 +55,8 @@
                 style="@style/tv_1"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:text="배경색"
                 android:maxLines="1"
+                android:text="배경색"
                 app:layout_constraintHeight_percent="0.07"
                 app:layout_constraintStart_toEndOf="@id/gl_v_8"
                 app:layout_constraintTop_toBottomOf="@id/view1"
@@ -76,27 +76,27 @@
                 android:layout_height="0dp"
                 android:background="@drawable/textview_background_1"
                 android:maxLines="1"
+                android:padding="5dp"
                 android:text="#000000"
                 app:layout_constraintHeight_percent="0.1"
                 app:layout_constraintStart_toEndOf="@id/gl_v_8"
                 app:layout_constraintTop_toBottomOf="@id/view2"
-                app:layout_constraintWidth_percent="0.8"
-                android:padding="5dp"/>
+                app:layout_constraintWidth_percent="0.8" />
 
             <View
                 android:id="@+id/view3"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                app:layout_constraintTop_toBottomOf="@id/tvBackgroundColor"
-                app:layout_constraintHeight_percent="0.1"/>
+                app:layout_constraintHeight_percent="0.1"
+                app:layout_constraintTop_toBottomOf="@id/tvBackgroundColor" />
 
             <TextView
                 android:id="@+id/tvTransparencyDescription"
                 style="@style/tv_1"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:text="투명도"
                 android:maxLines="1"
+                android:text="투명도"
                 app:layout_constraintHeight_percent="0.07"
                 app:layout_constraintStart_toEndOf="@id/gl_v_8"
                 app:layout_constraintTop_toBottomOf="@id/view3"
@@ -106,35 +106,31 @@
                 android:id="@+id/view4"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                app:layout_constraintTop_toBottomOf="@id/tvTransparencyDescription"
-                app:layout_constraintHeight_percent="0.02"/>
+                app:layout_constraintHeight_percent="0.02"
+                app:layout_constraintTop_toBottomOf="@id/tvTransparencyDescription" />
 
-            <com.google.android.material.slider.Slider
-                android:id="@+id/sliderTransparency"
+            <androidx.appcompat.widget.AppCompatSeekBar
+                android:id="@+id/seekBarTransparency"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/view4"
+                android:max="10"
+                android:theme="@style/Widget.AppCompat.SeekBar.Discrete"
                 app:layout_constraintStart_toStartOf="@id/gl_v_8"
-                app:layout_constraintWidth_percent="0.85"
-
-                android:valueFrom="0"
-                android:valueTo="10"
-                android:stepSize="1"/>
-
-
+                app:layout_constraintTop_toBottomOf="@id/view4"
+                app:layout_constraintWidth_percent="0.9" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btnOpenGallery"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            app:layout_constraintWidth_percent="0.8"
-            app:layout_constraintBottom_toTopOf="@id/btnGenerateRectangle"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
             android:backgroundTint="@color/teal_200"
+            android:enabled="false"
             android:text="사진 가져오기"
-            android:enabled="false"/>
+            app:layout_constraintBottom_toTopOf="@id/btnGenerateRectangle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintWidth_percent="0.8" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btnGenerateRectangle"
@@ -145,7 +141,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintWidth_percent="0.8"/>
+            app:layout_constraintWidth_percent="0.8" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-sw600dp/activity_rectangle.xml
+++ b/app/src/main/res/layout-sw600dp/activity_rectangle.xml
@@ -17,7 +17,7 @@
         app:layout_constraintWidth_percent="0.75" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/constraintLayoutRightSide"
+        android:id="@+id/constraintLayoutControlContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="#B9E1E6"
@@ -30,7 +30,7 @@
             android:id="@+id/constraintLayoutControl"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:visibility="visible"
+            android:visibility="invisible"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_percent="0.4"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout-sw600dp/activity_rectangle.xml
+++ b/app/src/main/res/layout-sw600dp/activity_rectangle.xml
@@ -52,7 +52,7 @@
 
             <TextView
                 android:id="@+id/tvBackgroundColorDescription"
-                style="@style/tv_1"
+                style="@style/tvPropertyDescription_600dp"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:maxLines="1"
@@ -92,7 +92,7 @@
 
             <TextView
                 android:id="@+id/tvTransparencyDescription"
-                style="@style/tv_1"
+                style="@style/tvPropertyDescription_600dp"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:maxLines="1"

--- a/app/src/main/res/layout/activity_rectangle.xml
+++ b/app/src/main/res/layout/activity_rectangle.xml
@@ -2,18 +2,159 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".rectangle.RectangleActivity"
-    android:id="@+id/constraintLayout">
+    tools:context=".rectangle.RectangleActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraintLayoutControlContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#B9E1E6"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/constraintLayoutControl"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintWidth_percent="0.65"
+            android:visibility="invisible">
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/gl_h_5"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:orientation="horizontal"
+                app:layout_constraintGuide_percent="0.05" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/gl_v_5"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.05" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/gl_v_95"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.95" />
+
+            <TextView
+                android:id="@+id/tvBackgroundColorDescription"
+                style="@style/tv_2"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:maxLines="1"
+                android:text="배경색"
+                app:layout_constraintHeight_percent="0.15"
+                app:layout_constraintStart_toStartOf="@id/gl_v_5"
+                app:layout_constraintTop_toTopOf="@id/gl_h_5"
+                app:layout_constraintWidth_percent="0.2" />
+
+            <View
+                android:id="@+id/view_1"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintBottom_toBottomOf="@id/tvBackgroundColorDescription"
+                app:layout_constraintStart_toEndOf="@id/tvBackgroundColorDescription"
+                app:layout_constraintTop_toTopOf="@id/tvBackgroundColorDescription"
+                app:layout_constraintWidth_percent="0.05" />
+
+            <TextView
+                android:id="@+id/tvBackgroundColor"
+                style="@style/tvBackgound"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="@drawable/textview_background_1"
+                android:maxLines="1"
+                android:padding="5dp"
+                android:text="#000000"
+                app:layout_constraintBottom_toBottomOf="@id/tvBackgroundColorDescription"
+                app:layout_constraintEnd_toEndOf="@id/gl_v_95"
+                app:layout_constraintStart_toEndOf="@id/view_1"
+                app:layout_constraintTop_toTopOf="@id/tvBackgroundColorDescription" />
+
+            <View
+                android:id="@+id/view_2"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintHeight_percent="0.05"
+                app:layout_constraintTop_toBottomOf="@id/tvBackgroundColorDescription" />
+
+            <TextView
+                android:id="@+id/tvTransparencyDescription"
+                style="@style/tv_2"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:maxLines="1"
+                android:text="투명도"
+                app:layout_constraintHeight_percent="0.15"
+                app:layout_constraintStart_toStartOf="@id/gl_v_5"
+                app:layout_constraintTop_toBottomOf="@id/view_2"
+                app:layout_constraintWidth_percent="0.2" />
+
+            <View
+                android:id="@+id/view_3"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintBottom_toBottomOf="@id/tvTransparencyDescription"
+                app:layout_constraintStart_toEndOf="@id/tvTransparencyDescription"
+                app:layout_constraintTop_toTopOf="@id/tvTransparencyDescription"
+                app:layout_constraintWidth_percent="0.03" />
+
+            <androidx.appcompat.widget.AppCompatSeekBar
+                android:id="@+id/seekBarTransparency"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:max="10"
+                android:theme="@style/Widget.AppCompat.SeekBar.Discrete"
+                app:layout_constraintBottom_toBottomOf="@id/view_3"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/view_3"
+                app:layout_constraintTop_toTopOf="@id/view_3" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnOpenGallery"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/teal_200"
+            android:enabled="false"
+            android:text="사진 가져오기"
+            app:layout_constraintBottom_toTopOf="@id/btnGenerateRectangle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/constraintLayoutControl"
+             />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnGenerateRectangle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:backgroundTint="#678CCC"
+            android:text="사각형 추가"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/constraintLayoutControl"
+           />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <com.codesquad_han.kotlin_drawingapp.rectangle.RectangleDrawingView
+        android:id="@+id/rectangleDrawingView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/constraintLayoutControlContainer" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_rectangle.xml
+++ b/app/src/main/res/layout/activity_rectangle.xml
@@ -49,7 +49,7 @@
 
             <TextView
                 android:id="@+id/tvBackgroundColorDescription"
-                style="@style/tv_2"
+                style="@style/tvPropertyDescription"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:maxLines="1"
@@ -91,7 +91,7 @@
 
             <TextView
                 android:id="@+id/tvTransparencyDescription"
-                style="@style/tv_2"
+                style="@style/tvPropertyDescription"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:maxLines="1"

--- a/app/src/main/res/values/text_style.xml
+++ b/app/src/main/res/values/text_style.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="tv_1">
+    <style name="tvPropertyDescription_600dp">
         <item name="android:textColor">@color/black</item>
         <item name="autoSizeMinTextSize">2sp</item>
         <item name="autoSizeTextType">uniform</item>
         <item name="android:gravity">left|center</item>
     </style>
 
-    <style name="tv_2">
+    <style name="tvPropertyDescription">
         <item name="android:textColor">@color/black</item>
         <item name="autoSizeMinTextSize">2sp</item>
         <item name="autoSizeTextType">uniform</item>

--- a/app/src/main/res/values/text_style.xml
+++ b/app/src/main/res/values/text_style.xml
@@ -8,6 +8,13 @@
         <item name="android:gravity">left|center</item>
     </style>
 
+    <style name="tv_2">
+        <item name="android:textColor">@color/black</item>
+        <item name="autoSizeMinTextSize">2sp</item>
+        <item name="autoSizeTextType">uniform</item>
+        <item name="android:gravity">center</item>
+    </style>
+
     <style name="tvBackgound">
         <item name="android:textColor">@color/black</item>
         <item name="autoSizeMinTextSize">2sp</item>


### PR DESCRIPTION
- 기존의 투명도 조절 시 material design의 slider를 사용했으나 seekbar로 교체했습니다

- 태블릿 외 레이아웃에서도 실행되도록 수정했습니다

- 선택된 사각형을 두 손가락으로 드래그 할 수 있도록 구현했습니다
- 드래그 하는 동안 선택된 사각형의 상태는 유지되고, 임시뷰를 통해 이동할 위치를 정하도록 했습니다

https://user-images.githubusercontent.com/69443895/157416734-df4c9980-f37b-4899-b2fd-37d16bc3166d.mp4


