### PR TITLE
[히데]  텍스트 클릭시 테두리 표시& 기존 기능 적용  ,   리스트 레이어 추가 및 리스트 아이템에 이벤트 추가

### DIFF
--- a/app/src/main/java/model/Plane.kt
+++ b/app/src/main/java/model/Plane.kt
@@ -96,5 +96,7 @@ class Plane(private val context: Context) {
         selectedRect?.size?.value = (Size(width,height))
     }
 
-
+    fun getCustomRectangleById(rectId: String): Rect? {
+        return customRectangleList.find { it.rectId==rectId }
+    }
 }

--- a/app/src/main/java/model/Size.kt
+++ b/app/src/main/java/model/Size.kt
@@ -1,6 +1,6 @@
 package model
 
-data class Size(var width: Int, var height: Int) {
+data class Size(val width: Int, val height: Int) {
     override fun toString(): String {
         return "W$width, H$height,"
     }

--- a/app/src/main/java/presenter/MainPresenter.kt
+++ b/app/src/main/java/presenter/MainPresenter.kt
@@ -2,6 +2,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import model.Photo
 import model.Plane
+import model.Sentence
 import view.MainContract
 import view.RectView
 
@@ -28,10 +29,17 @@ class MainPresenter(
     }
 
     override fun changePosition(rectView: RectView) {
+
         plane.changePosition(rectView.rectId, rectView.left.toInt(), rectView.top.toInt())?.let{
-
-
-            view.redrawRectangle(it)
+            if(rectView.photoId==""&&rectView.text==""){
+                view.redrawRectangle(it)
+            }
+            else if(rectView.text!=""){
+                view.redrawSentence(it as Sentence)
+            }
+            else{
+                view.redrawPhoto(it as Photo)
+            }
         }
     }
 

--- a/app/src/main/java/presenter/MainPresenter.kt
+++ b/app/src/main/java/presenter/MainPresenter.kt
@@ -18,6 +18,12 @@ class MainPresenter(
 
     }
 
+    override fun selectRectangleByList(rectId: String) {
+        plane.getCustomRectangleById(rectId)?.let{
+            view.displaySelectedRectAttribute(it)
+        }
+    }
+
     override fun changeColor(rectView: RectView) {
         if (rectView.photoId == "") {
             plane.changeColor(rectView.rectId)

--- a/app/src/main/java/view/CustomRectInfoView.kt
+++ b/app/src/main/java/view/CustomRectInfoView.kt
@@ -1,0 +1,28 @@
+package view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.codesquad.kotlin_drawingapp.R
+
+
+class CustomRectInfoView(
+    context: Context,
+    name: String,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    defStyleRes: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr, defStyleRes) {
+
+    init {
+        LayoutInflater.from(context).inflate(R.layout.customview_layer, this, true)
+        val text: TextView = findViewById(R.id.tv_name)
+        val image: ImageView = findViewById(R.id.iv_figure)
+        text.text = name
+    }
+    
+
+}

--- a/app/src/main/java/view/CustomRectInfoView.kt
+++ b/app/src/main/java/view/CustomRectInfoView.kt
@@ -17,12 +17,14 @@ class CustomRectInfoView(
     defStyleRes: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr, defStyleRes) {
 
+    var rectId=""
+    val photoId=""
     init {
         LayoutInflater.from(context).inflate(R.layout.customview_layer, this, true)
         val text: TextView = findViewById(R.id.tv_name)
         val image: ImageView = findViewById(R.id.iv_figure)
         text.text = name
     }
-    
+
 
 }

--- a/app/src/main/java/view/MainActivity.kt
+++ b/app/src/main/java/view/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.provider.Settings
+import android.util.Log
 import android.view.MotionEvent
 import android.widget.*
 import androidx.activity.result.ActivityResultLauncher
@@ -24,7 +25,7 @@ import androidx.lifecycle.Observer
 import com.codesquad.kotlin_drawingapp.R
 import model.*
 
-private const val REQUEST_CODE= 1000
+private const val REQUEST_CODE = 1000
 
 class MainActivity : AppCompatActivity(), MainContract.View {
 
@@ -32,14 +33,16 @@ class MainActivity : AppCompatActivity(), MainContract.View {
     private lateinit var presenter: MainPresenter
     private var selectedCustomRectangleView: RectView? = null
     private lateinit var tvRgbValue: TextView
-    private lateinit var editTvWidth:EditText
-    private lateinit var editTvHeight:EditText
-    private lateinit var editTvXpos:EditText
-    private lateinit var editTvYpos:EditText
+    private lateinit var editTvWidth: EditText
+    private lateinit var editTvHeight: EditText
+    private lateinit var editTvXpos: EditText
+    private lateinit var editTvYpos: EditText
     private lateinit var layer: LinearLayout
     private var squareIndex = 1
     private var textIndex = 1
-    private var photoIndex= 1
+    private var photoIndex = 1
+    private var rectCount = 0
+    private var customRectInfoViewList: ArrayList<CustomRectInfoView> = ArrayList(100)
     private lateinit var customLayerView: CustomRectInfoView
     private val backgroundObserver = Observer<BackGroundColor> { colorValue ->
         selectedCustomRectangleView?.changeColor(colorValue)
@@ -50,13 +53,13 @@ class MainActivity : AppCompatActivity(), MainContract.View {
     }
     private val customRectangleViewList: ArrayList<RectView> = arrayListOf()
     private var selectedRectangle: Rect? = null
-    private val sizeObserver = Observer<Size> { size->
+    private val sizeObserver = Observer<Size> { size ->
         selectedCustomRectangleView?.changeSize(size.width, size.height)
         editTvWidth.setText("${size.width}")
         editTvHeight.setText("${size.height}")
 
     }
-    private val posObserver = Observer<Point> { point->
+    private val posObserver = Observer<Point> { point ->
         selectedCustomRectangleView?.changePos(point.xPos.toFloat(), point.yPos.toFloat())
         editTvXpos.setText("${point.xPos}")
         editTvYpos.setText("${point.yPos}")
@@ -68,30 +71,39 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         setContentView(R.layout.activity_main)
         presenter = MainPresenter(this, this)
         mainLayout = findViewById(R.id.image_container)
-        layer= findViewById(R.id.linear_list)
+        layer = findViewById(R.id.linear_list)
         val btnMakeRectangle = findViewById<Button>(R.id.btn_addRectangle)
         val opacitySeekBar = findViewById<SeekBar>(R.id.seekbar_opacity)
         val btnMakePhotoView = findViewById<Button>(R.id.btn_addPhoto)
-        val btnMakeSentenceView= findViewById<Button>(R.id.btn_addSentence)
+        val btnMakeSentenceView = findViewById<Button>(R.id.btn_addSentence)
         tvRgbValue = findViewById<TextView>(R.id.tv_rgb_value)
-        val btnWidthUp= findViewById<Button>(R.id.btn_width_up)
-        val btnWidthDown= findViewById<Button>(R.id.btn_width_down)
-        val btnHeightUp= findViewById<Button>(R.id.btn_height_up)
-        val btnHeightDown= findViewById<Button>(R.id.btn_height_down)
-        val btnXposUp= findViewById<Button>(R.id.btn_xPos_up)
-        val btnYposUp= findViewById<Button>(R.id.btn_yPos_up)
-        val btnXposDown= findViewById<Button>(R.id.btn_xPos_down)
-        val btnYposDown= findViewById<Button>(R.id.btn_yPos_down)
-        editTvWidth= findViewById<EditText>(R.id.editText_width)
-        editTvHeight= findViewById<EditText>(R.id.editText_height)
-        editTvXpos= findViewById<EditText>(R.id.editText_xPos)
-        editTvYpos= findViewById<EditText>(R.id.editText_yPos)
+        val btnWidthUp = findViewById<Button>(R.id.btn_width_up)
+        val btnWidthDown = findViewById<Button>(R.id.btn_width_down)
+        val btnHeightUp = findViewById<Button>(R.id.btn_height_up)
+        val btnHeightDown = findViewById<Button>(R.id.btn_height_down)
+        val btnXposUp = findViewById<Button>(R.id.btn_xPos_up)
+        val btnYposUp = findViewById<Button>(R.id.btn_yPos_up)
+        val btnXposDown = findViewById<Button>(R.id.btn_xPos_down)
+        val btnYposDown = findViewById<Button>(R.id.btn_yPos_down)
+        editTvWidth = findViewById<EditText>(R.id.editText_width)
+        editTvHeight = findViewById<EditText>(R.id.editText_height)
+        editTvXpos = findViewById<EditText>(R.id.editText_xPos)
+        editTvYpos = findViewById<EditText>(R.id.editText_yPos)
         tvRgbValue = findViewById<TextView>(R.id.tv_rgb_value)
         btnMakeRectangle.setOnClickListener {
-            presenter.createRectanglePaint()
-            customLayerView= CustomRectInfoView(this, "Rect $squareIndex")
+            customLayerView = CustomRectInfoView(this, "Rect $squareIndex")
             squareIndex++
             layer.addView(customLayerView)
+            customRectInfoViewList.add(customLayerView)
+            presenter.createRectanglePaint()
+            customLayerView.setOnClickListener {
+                Log.d("test","Clcicked")
+                customRectangleViewList.map { it.eraseBorder() }
+                selectedRectangle?.opacity?.removeObserver(opacityObserver)
+                selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
+                presenter.selectRectangleByList(customLayerView.rectId)
+            }
+
         }
 
         btnMakePhotoView.setOnClickListener {
@@ -106,7 +118,8 @@ class MainActivity : AppCompatActivity(), MainContract.View {
                     else -> {
                         requestPermissions(
                             arrayOf(android.Manifest.permission.READ_EXTERNAL_STORAGE),
-                            REQUEST_CODE)
+                            REQUEST_CODE
+                        )
                     }
                 }
             }
@@ -114,12 +127,21 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         }
 
         btnMakeSentenceView.setOnClickListener {
-            presenter.createSentencePaint()
-            customLayerView= CustomRectInfoView(this, "Text $textIndex")
+            customLayerView = CustomRectInfoView(this, "Text $textIndex")
             textIndex++
             layer.addView(customLayerView)
+            customRectInfoViewList.add(customLayerView)
+            presenter.createSentencePaint()
+            customLayerView.setOnClickListener {
+                customRectangleViewList.map { it.eraseBorder() }
+                selectedRectangle?.opacity?.removeObserver(opacityObserver)
+                selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
+                presenter.selectRectangleByList(customLayerView.rectId)
+            }
+
         }
         mainLayout.setOnTouchListener { _, motionEvent ->
+            Log.d("test","Touched")
             if (motionEvent.action == MotionEvent.ACTION_DOWN) {
                 customRectangleViewList.map { it.eraseBorder() }
                 selectedRectangle?.opacity?.removeObserver(opacityObserver)
@@ -151,7 +173,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
 
         btnHeightDown.setOnClickListener {
             selectedCustomRectangleView?.let {
-                if(it.rectHeight!=1) {
+                if (it.rectHeight != 1) {
                     presenter.changeSize(it, "height", -1)
                 }
             }
@@ -159,7 +181,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
 
         btnWidthDown.setOnClickListener {
             selectedCustomRectangleView?.let {
-                if(it.rectWidth!=1) {
+                if (it.rectWidth != 1) {
                     presenter.changeSize(it, "width", -1)
                 }
             }
@@ -184,7 +206,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         }
         btnXposDown.setOnClickListener {
             selectedCustomRectangleView?.let {
-                if(it.left.toInt()!=1) {
+                if (it.left.toInt() != 1) {
                     presenter.changeXpos(it, -1)
                 }
             }
@@ -198,18 +220,20 @@ class MainActivity : AppCompatActivity(), MainContract.View {
 
         btnYposDown.setOnClickListener {
             selectedCustomRectangleView?.let {
-                if(it.top.toInt()!=1) {
+                if (it.top.toInt() != 1) {
                     presenter.changeYPos(it, -1)
                 }
             }
         }
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int,
-                                            permissions: Array<String>, grantResults: IntArray) {
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<String>, grantResults: IntArray
+    ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         when (requestCode) {
-            REQUEST_CODE-> {
+            REQUEST_CODE -> {
                 if ((grantResults.isNotEmpty() &&
                             grantResults[0] == PackageManager.PERMISSION_GRANTED)
                 ) {
@@ -227,7 +251,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         AlertDialog.Builder(this).setTitle("권한이 필요합니다")
             .setMessage("사진을 불러오기 위해 권한설정이 필요합니다")
             .setPositiveButton("설정하러가기") { _, _ ->
-                val intent= Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
                     .setData(Uri.parse("package:$packageName"));
                 startActivity(intent)
             }
@@ -262,10 +286,18 @@ class MainActivity : AppCompatActivity(), MainContract.View {
                                 ImageDecoder.createSource(this.contentResolver, currentImageUri)
                             bitmap = ImageDecoder.decodeBitmap(source)
                         }
-                        presenter.createPhotoPaint(bitmap)
-                        customLayerView= CustomRectInfoView(this, "Photo $photoIndex")
+
+                        customLayerView = CustomRectInfoView(this, "Photo $photoIndex")
                         photoIndex++
                         layer.addView(customLayerView)
+                        customRectInfoViewList.add(customLayerView)
+                        presenter.createPhotoPaint(bitmap)
+                        customLayerView.setOnClickListener {
+                            customRectangleViewList.map { it.eraseBorder() }
+                            selectedRectangle?.opacity?.removeObserver(opacityObserver)
+                            selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
+                            presenter.selectRectangleByList(customLayerView.rectId)
+                        }
                     }
 
                 } catch (e: Exception) {
@@ -285,17 +317,17 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         selectedCustomRectangleView?.drawBorder()
         val rgbValueTextView = findViewById<TextView>(R.id.tv_rgb_value)
         val opacitySeekBar = findViewById<SeekBar>(R.id.seekbar_opacity)
-        val editTvWidth= findViewById<EditText>(R.id.editText_width)
-        val editTvHeight= findViewById<EditText>(R.id.editText_height)
-        val editTvXpos= findViewById<EditText>(R.id.editText_xPos)
-        val editTvYpos= findViewById<EditText>(R.id.editText_yPos)
-        var tempView= RectView(this)
+        val editTvWidth = findViewById<EditText>(R.id.editText_width)
+        val editTvHeight = findViewById<EditText>(R.id.editText_height)
+        val editTvXpos = findViewById<EditText>(R.id.editText_xPos)
+        val editTvYpos = findViewById<EditText>(R.id.editText_yPos)
+        var tempView = RectView(this)
         editTvHeight.setText("${rect.size.value?.height}")
         editTvWidth.setText("${rect.size.value?.width}")
         editTvXpos.setText("${rect.point.value?.xPos}")
         editTvYpos.setText("${rect.point.value?.yPos}")
-        tempView.isVisible= false
-        if (selectedCustomRectangleView?.photoId == ""&&selectedCustomRectangleView?.text=="") {
+        tempView.isVisible = false
+        if (selectedCustomRectangleView?.photoId == "" && selectedCustomRectangleView?.text == "") {
             rgbValueTextView.text = rect.backGroundColor.value?.getRGBHexValue()
             rect.opacity.value?.let {
                 opacitySeekBar.progress = it
@@ -304,22 +336,20 @@ class MainActivity : AppCompatActivity(), MainContract.View {
             rect.opacity.observe(this, opacityObserver)
 
             tempView.drawRectangle(rect)
-        }
-        else if(selectedCustomRectangleView?.text!=""){
+        } else if (selectedCustomRectangleView?.text != "") {
             rgbValueTextView.text = "No Color"
             rect.opacity.value?.let {
                 opacitySeekBar.progress = it
             }
             rect.opacity.observe(this, opacityObserver)
             tempView.drawSentence(rect as Sentence)
-        }
-        else {
+        } else {
             rgbValueTextView.text = "No Color"
             rect.opacity.value?.let {
                 opacitySeekBar.progress = it
             }
             rect.opacity.observe(this, opacityObserver)
-            selectedCustomRectangleView?.bitmap?.let{
+            selectedCustomRectangleView?.bitmap?.let {
                 tempView.drawPhoto(it, rect as Photo)
             }
         }
@@ -329,9 +359,9 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         tempView.changeOpacity(5)
         mainLayout.addView(tempView)
         selectedCustomRectangleView?.setOnTouchListener { view, motionEvent ->
-            tempView.isVisible=true
+            tempView.isVisible = true
             if (motionEvent.action == MotionEvent.ACTION_MOVE) {
-                selectedCustomRectangleView?.onTouch(motionEvent,tempView)
+                selectedCustomRectangleView?.onTouch(motionEvent, tempView)
                 tempView.invalidate()
             } else if (motionEvent.action == MotionEvent.ACTION_UP) {
                 selectedCustomRectangleView?.let {
@@ -350,7 +380,8 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         rectView.drawRectangle(rect)
         mainLayout.addView(rectView)
         customRectangleViewList.add(rectView)
-
+        customRectInfoViewList[rectCount].rectId = rect.rectId
+        rectCount++
     }
 
     override fun drawPhoto(photo: Photo) {
@@ -359,6 +390,8 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         rectView.drawPhoto(image, photo)
         mainLayout.addView(rectView)
         customRectangleViewList.add(rectView)
+        customRectInfoViewList[rectCount].rectId = photo.rectId
+        rectCount++
     }
 
     override fun drawSentence(sentence: Sentence) {
@@ -366,6 +399,8 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         rectView.drawSentence(sentence)
         mainLayout.addView(rectView)
         customRectangleViewList.add(rectView)
+        customRectInfoViewList[rectCount].rectId = sentence.rectId
+        rectCount++
     }
 
     override fun redrawRectangle(rect: Rect) {
@@ -382,8 +417,8 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         mainLayout.removeView(selectedCustomRectangleView)
         customRectangleViewList.remove(selectedCustomRectangleView)
         val rectView = RectView(this)
-        selectedCustomRectangleView?.bitmap?.let{
-            rectView.drawPhoto(it,photo)
+        selectedCustomRectangleView?.bitmap?.let {
+            rectView.drawPhoto(it, photo)
         }
         selectedCustomRectangleView = rectView
         mainLayout.addView(rectView)

--- a/app/src/main/java/view/MainActivity.kt
+++ b/app/src/main/java/view/MainActivity.kt
@@ -279,7 +279,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         editTvXpos.setText("${rect.point.value?.xPos}")
         editTvYpos.setText("${rect.point.value?.yPos}")
         tempView.isVisible= false
-        if (selectedCustomRectangleView?.photoId == "") {
+        if (selectedCustomRectangleView?.photoId == ""&&selectedCustomRectangleView?.text=="") {
             rgbValueTextView.text = rect.backGroundColor.value?.getRGBHexValue()
             rect.opacity.value?.let {
                 opacitySeekBar.progress = it
@@ -288,7 +288,16 @@ class MainActivity : AppCompatActivity(), MainContract.View {
             rect.opacity.observe(this, opacityObserver)
 
             tempView.drawRectangle(rect)
-        } else {
+        }
+        else if(selectedCustomRectangleView?.text!=""){
+            rgbValueTextView.text = "No Color"
+            rect.opacity.value?.let {
+                opacitySeekBar.progress = it
+            }
+            rect.opacity.observe(this, opacityObserver)
+            tempView.drawSentence(rect as Sentence)
+        }
+        else {
             rgbValueTextView.text = "No Color"
             rect.opacity.value?.let {
                 opacitySeekBar.progress = it
@@ -360,6 +369,16 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         selectedCustomRectangleView?.bitmap?.let{
             rectView.drawPhoto(it,photo)
         }
+        selectedCustomRectangleView = rectView
+        mainLayout.addView(rectView)
+        customRectangleViewList.add(rectView)
+    }
+
+    override fun redrawSentence(sentence: Sentence) {
+        mainLayout.removeView(selectedCustomRectangleView)
+        customRectangleViewList.remove(selectedCustomRectangleView)
+        val rectView = RectView(this)
+        rectView.drawSentence(sentence)
         selectedCustomRectangleView = rectView
         mainLayout.addView(rectView)
         customRectangleViewList.add(rectView)

--- a/app/src/main/java/view/MainActivity.kt
+++ b/app/src/main/java/view/MainActivity.kt
@@ -36,6 +36,11 @@ class MainActivity : AppCompatActivity(), MainContract.View {
     private lateinit var editTvHeight:EditText
     private lateinit var editTvXpos:EditText
     private lateinit var editTvYpos:EditText
+    private lateinit var layer: LinearLayout
+    private var squareIndex = 1
+    private var textIndex = 1
+    private var photoIndex= 1
+    private lateinit var customLayerView: CustomRectInfoView
     private val backgroundObserver = Observer<BackGroundColor> { colorValue ->
         selectedCustomRectangleView?.changeColor(colorValue)
         tvRgbValue.text = colorValue.getRGBHexValue()
@@ -56,12 +61,14 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         editTvXpos.setText("${point.xPos}")
         editTvYpos.setText("${point.yPos}")
     }
+
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         presenter = MainPresenter(this, this)
         mainLayout = findViewById(R.id.image_container)
+        layer= findViewById(R.id.linear_list)
         val btnMakeRectangle = findViewById<Button>(R.id.btn_addRectangle)
         val opacitySeekBar = findViewById<SeekBar>(R.id.seekbar_opacity)
         val btnMakePhotoView = findViewById<Button>(R.id.btn_addPhoto)
@@ -82,6 +89,9 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         tvRgbValue = findViewById<TextView>(R.id.tv_rgb_value)
         btnMakeRectangle.setOnClickListener {
             presenter.createRectanglePaint()
+            customLayerView= CustomRectInfoView(this, "Rect $squareIndex")
+            squareIndex++
+            layer.addView(customLayerView)
         }
 
         btnMakePhotoView.setOnClickListener {
@@ -105,6 +115,9 @@ class MainActivity : AppCompatActivity(), MainContract.View {
 
         btnMakeSentenceView.setOnClickListener {
             presenter.createSentencePaint()
+            customLayerView= CustomRectInfoView(this, "Text $textIndex")
+            textIndex++
+            layer.addView(customLayerView)
         }
         mainLayout.setOnTouchListener { _, motionEvent ->
             if (motionEvent.action == MotionEvent.ACTION_DOWN) {
@@ -250,6 +263,9 @@ class MainActivity : AppCompatActivity(), MainContract.View {
                             bitmap = ImageDecoder.decodeBitmap(source)
                         }
                         presenter.createPhotoPaint(bitmap)
+                        customLayerView= CustomRectInfoView(this, "Photo $photoIndex")
+                        photoIndex++
+                        layer.addView(customLayerView)
                     }
 
                 } catch (e: Exception) {

--- a/app/src/main/java/view/MainContract.kt
+++ b/app/src/main/java/view/MainContract.kt
@@ -14,6 +14,7 @@ interface MainContract {
         fun drawSentence(sentence: Sentence)
         fun redrawRectangle(rect:Rect)
         fun redrawPhoto(photo: Photo)
+        fun redrawSentence(sentence: Sentence)
     }
 
     interface Presenter {

--- a/app/src/main/java/view/MainContract.kt
+++ b/app/src/main/java/view/MainContract.kt
@@ -19,6 +19,7 @@ interface MainContract {
 
     interface Presenter {
         fun selectRectangle(xPos: Float, yPos: Float)
+        fun selectRectangleByList(rectId:String)
         fun changeColor(rectView: RectView)
         fun changeOpacity(rectView: RectView, opacity: Int)
         fun changePosition(rectView: RectView)

--- a/app/src/main/java/view/RectView.kt
+++ b/app/src/main/java/view/RectView.kt
@@ -59,8 +59,7 @@ class RectView(context: Context) : View(context) {
                 canvas.drawRect(left, top, right, bottom, borderPaint)
             }
             else{
-
-                canvas.drawRect(left, top, left+textWidth, top+textHeight, borderPaint)
+                canvas.drawRect(left, top-textHeight, left+textWidth, top+textHeight, borderPaint)
             }
 
         }

--- a/app/src/main/java/view/RectView.kt
+++ b/app/src/main/java/view/RectView.kt
@@ -23,7 +23,7 @@ class RectView(context: Context) : View(context) {
     private var right = 0.0F
     var top = 0.0F
     private var bottom = 0.0F
-    private var text=""
+    var text=""
     var rectWidth = 0
     var rectHeight = 0
     var textWidth= 0

--- a/app/src/main/res/layout-sw600dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp-land/activity_main.xml
@@ -7,12 +7,37 @@
     android:layout_height="match_parent"
     tools:context="view.MainActivity">
 
+    <LinearLayout
+        android:id="@+id/linear_list"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:orientation="vertical"
+        android:background="@color/sideBar"
+        >
+
+        <TextView
+            android:id="@+id/tv_list_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="리스트"
+            android:textColor="@color/black"
+            android:layout_marginLeft="50dp"
+            android:layout_marginTop="50dp"
+            android:layout_marginRight="50dp"
+
+            >
+
+        </TextView>
+    </LinearLayout>
+
     <FrameLayout
         android:id="@+id/image_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:layout_editor_absoluteX="-170dp"
-        tools:layout_editor_absoluteY="160dp">
+        tools:layout_editor_absoluteX="-594dp"
+        tools:layout_editor_absoluteY="127dp">
 
     </FrameLayout>
 

--- a/app/src/main/res/layout-sw600dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp-land/activity_main.xml
@@ -11,21 +11,20 @@
         android:id="@+id/linear_list"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:orientation="vertical"
         android:background="@color/sideBar"
-        >
+        android:orientation="vertical"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:id="@+id/tv_list_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="리스트"
-            android:textColor="@color/black"
             android:layout_marginLeft="50dp"
             android:layout_marginTop="50dp"
             android:layout_marginRight="50dp"
+            android:text="리스트"
+            android:textColor="@color/black"
 
             >
 
@@ -34,14 +33,18 @@
 
     <FrameLayout
         android:id="@+id/image_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:layout_editor_absoluteX="-594dp"
-        tools:layout_editor_absoluteY="127dp">
+        android:layout_width="1300dp"
+        android:layout_height="900dp"
+        app:layout_constraintEnd_toStartOf="@+id/relativeLayout"
+        app:layout_constraintStart_toEndOf="@+id/linear_list"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        >
 
     </FrameLayout>
 
     <RelativeLayout
+        android:id="@+id/relativeLayout"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:background="@color/sideBar"
@@ -162,8 +165,8 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/linear_xPos"
             android:layout_marginStart="15dp"
-            android:layout_marginEnd="15dp"
             android:layout_marginTop="10dp"
+            android:layout_marginEnd="15dp"
             android:background="@drawable/imageview_border"
             android:orientation="horizontal">
 

--- a/app/src/main/res/layout/customview_layer.xml
+++ b/app/src/main/res/layout/customview_layer.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="20dp"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp">
+
+    <ImageView
+        android:id="@+id/iv_figure"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="thumbnail"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/tv_name"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="15dp"
+        android:textColor="@color/black"
+        android:text="Text 1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/iv_figure"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
* 텍스트 추가 구현
   *  사각형, 사진 뷰와 다르게 border 처리 추가
   *  클릭시  기존 사각형, 사진에 가능했던 드래그, 투명도 변경 가능하도록 수정

* 리스트 레이어
   *  메인 레이아웃에 리스트 레이어를 위한 레이아웃 추가
   * 리스트 아이템을 위한 커스템 뷰추가
   * 아이템 생성시 리스트 아이템도 생성되도록 구현
   * 아이템에 클릭 이벤트 리스너 구현  ->   기존 화면 터치 이벤트와 충돌로,  아이템 클릭 이벤트 작동은 수정중,
   * 아이템에  섬네일 이미지 부분  미구현