### PR TITLE
[wooki] 피드백 질문 및 오브젝트 목록 표시 일부 구현

### DIFF
--- a/app/src/main/java/com/example/kotlin_drawingapp/MainActivity.kt
+++ b/app/src/main/java/com/example/kotlin_drawingapp/MainActivity.kt
@@ -11,6 +11,7 @@ import android.util.Size
 import android.widget.SeekBar
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import com.example.kotlin_drawingapp.customview.CustomLayerListView
 import com.example.kotlin_drawingapp.customview.NumberUpDownView
 import com.example.kotlin_drawingapp.databinding.ActivityMainBinding
 import com.example.kotlin_drawingapp.model.Color
@@ -126,10 +127,17 @@ class MainActivity : AppCompatActivity(), MainContract.View {
                 }
             }
         })
+
+        binding.layoutObjectList.setOnClickListItemListener(object : CustomLayerListView.OnClickListItemListener {
+            override fun onClick(drawObject: DrawObject) {
+                presenter.selectDrawObject(drawObject.currentPoint.x.toFloat(), drawObject.currentPoint.y.toFloat())
+            }
+        })
     }
 
     override fun showDrawObject(drawObject: List<DrawObject>) {
         binding.drawView.draw(drawObject)
+        binding.layoutObjectList.updateDrawObjectList(drawObject)
     }
 
     override fun showDrawObjectInfo(color: Color, alpha: Int, point: Point, size: Size) {

--- a/app/src/main/java/com/example/kotlin_drawingapp/MainPresenter.kt
+++ b/app/src/main/java/com/example/kotlin_drawingapp/MainPresenter.kt
@@ -54,7 +54,7 @@ class MainPresenter(
             when (replacement) {
                 is DrawObject.Rectangle -> replacement.alpha = alpha
                 is DrawObject.Image -> replacement.alpha = alpha
-                is DrawObject.CustomTextView -> replacement.alpha = alpha
+                is DrawObject.CustomText -> replacement.alpha = alpha
             }
             drawingRepository.saveCurrentSelectedDrawObject(replacement)
             drawingRepository.modifyDrawObject(tmpCurrentSelectedDrawObject, replacement)
@@ -78,7 +78,7 @@ class MainPresenter(
             when (drawObject) {
                 is DrawObject.Rectangle -> mainView.showDrawObjectInfo(drawObject.rgb, drawObject.alpha, drawObject.currentPoint, drawObject.currentSize)
                 is DrawObject.Image -> mainView.showDrawObjectInfo(Color(255, 255, 255), drawObject.alpha, drawObject.currentPoint, drawObject.currentSize)
-                is DrawObject.CustomTextView -> mainView.showDrawObjectInfo(
+                is DrawObject.CustomText -> mainView.showDrawObjectInfo(
                     Color(drawObject.paint.color.red, drawObject.paint.color.green, drawObject.paint.color.blue)
                     , drawObject.alpha,
                     drawObject.currentPoint,

--- a/app/src/main/java/com/example/kotlin_drawingapp/customview/CustomLayerListView.kt
+++ b/app/src/main/java/com/example/kotlin_drawingapp/customview/CustomLayerListView.kt
@@ -1,0 +1,45 @@
+package com.example.kotlin_drawingapp.customview
+
+import android.content.Context
+import android.graphics.Canvas
+import android.util.AttributeSet
+import android.util.Log
+import android.view.MotionEvent
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import com.example.kotlin_drawingapp.R
+import com.example.kotlin_drawingapp.model.draw.DrawObject
+
+class CustomLayerListView(context: Context?, attrs: AttributeSet?) : LinearLayout(context, attrs) {
+    interface OnClickListItemListener {
+        fun onClick(drawObject: DrawObject)
+    }
+    private var clickListItemListener: OnClickListItemListener? = null
+    fun setOnClickListItemListener(listener: OnClickListItemListener) {
+        clickListItemListener = listener
+    }
+
+    private var drawObjectList = listOf<DrawObject>()
+    fun updateDrawObjectList(drawObject: List<DrawObject>) {
+        drawObjectList = drawObject
+
+        removeAllViews()
+        drawObjectList.forEach {
+            addView(createCustomLayerTextView(it))
+        }
+    }
+
+    override fun onDraw(canvas: Canvas?) {
+        super.onDraw(canvas)
+    }
+
+    private fun createCustomLayerTextView(drawObject: DrawObject): CustomLayerTextView {
+        val textView = CustomLayerTextView(context, drawObject)
+        textView.setOnClickLayerTextViewListener(object : CustomLayerTextView.OnClickLayerTextViewListener {
+            override fun onClick(drawObject: DrawObject) {
+                clickListItemListener?.onClick(drawObject)
+            }
+        })
+        return textView
+    }
+}

--- a/app/src/main/java/com/example/kotlin_drawingapp/customview/CustomLayerTextView.kt
+++ b/app/src/main/java/com/example/kotlin_drawingapp/customview/CustomLayerTextView.kt
@@ -1,0 +1,73 @@
+package com.example.kotlin_drawingapp.customview
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Rect
+import android.util.Log
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import androidx.core.content.res.ResourcesCompat
+import com.example.kotlin_drawingapp.R
+import com.example.kotlin_drawingapp.model.draw.DrawObject
+
+class CustomLayerTextView private constructor(context: Context)
+    : androidx.appcompat.widget.AppCompatTextView(context) {
+
+    private lateinit var property: DrawObject
+    constructor(context: Context, drawObject: DrawObject): this(context) {
+        layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 80)
+        when(drawObject) {
+            is DrawObject.Rectangle -> {
+                text = "사각형"
+                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_baseline_crop_square_24, 0, 0, 0)
+            }
+            is DrawObject.Image -> {
+                text = "이미지"
+                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_baseline_image_24, 0, 0, 0)
+            }
+            is DrawObject.CustomText -> {
+                text = "텍스트"
+                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_baseline_text_format_24, 0, 0, 0)
+            }
+        }
+        background = ResourcesCompat.getDrawable(resources, R.drawable.layout_border, null)
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(4, 0, 0, 0)
+        property = drawObject
+    }
+
+    interface OnClickLayerTextViewListener {
+        fun onClick(drawObject: DrawObject)
+    }
+    private var clickLayerTextViewListener: OnClickLayerTextViewListener? = null
+    fun setOnClickLayerTextViewListener(listener: OnClickLayerTextViewListener) {
+        clickLayerTextViewListener = listener
+    }
+
+    override fun onDraw(canvas: Canvas?) {
+        if (property.selected) {
+            setBackgroundColor(Color.GRAY)
+        }
+
+        super.onDraw(canvas)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent?): Boolean {
+        when (event?.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                property.apply {
+                    clickLayerTextViewListener?.onClick(this)
+                }
+            }
+        }
+
+        return super.onTouchEvent(event)
+    }
+}

--- a/app/src/main/java/com/example/kotlin_drawingapp/model/CustomTextViewFactory.kt
+++ b/app/src/main/java/com/example/kotlin_drawingapp/model/CustomTextViewFactory.kt
@@ -13,7 +13,7 @@ class CustomTextViewFactory : Factory() {
 
         private fun createRandomString(): String {
             val randomStart = Random.nextInt(0, textSplit.size - 5)
-            var randomStringBuilder = StringBuilder()
+            val randomStringBuilder = StringBuilder()
             for (index in randomStart until randomStart + 5) {
                 randomStringBuilder.append(textSplit[index])
                     .append(' ')
@@ -42,14 +42,14 @@ class CustomTextViewFactory : Factory() {
             return Size(bounds.width(), bounds.height())
         }
 
-        fun create(): DrawObject.CustomTextView {
+        fun create(): DrawObject.CustomText {
             val text = createRandomString()
             val endPos = getRandomEndPos(text)
             val alpha = randomAlpha()
             val paint = createPaint(Random.nextInt(50, 100), randomColor(), alpha)
             val textViewSize = getTextViewSize(text, paint, endPos)
 
-            return DrawObject.CustomTextView(
+            return DrawObject.CustomText(
                 randomId(),
                 textViewSize,
                 randomPoint(),

--- a/app/src/main/java/com/example/kotlin_drawingapp/model/draw/DrawObject.kt
+++ b/app/src/main/java/com/example/kotlin_drawingapp/model/draw/DrawObject.kt
@@ -59,7 +59,7 @@ sealed class DrawObject {
         }
     }
 
-    data class CustomTextView(
+    data class CustomText(
         val id: String,
         private var size: Size,
         private var point: Point,
@@ -74,7 +74,7 @@ sealed class DrawObject {
         }
 
         override fun createNewDrawObject(size: Size, point: Point): DrawObject {
-            return CustomTextView(id, size, point, endPos, paint, text, alpha)
+            return CustomText(id, size, point, endPos, paint, text, alpha)
         }
     }
 

--- a/app/src/main/java/com/example/kotlin_drawingapp/model/draw/DrawView.kt
+++ b/app/src/main/java/com/example/kotlin_drawingapp/model/draw/DrawView.kt
@@ -61,7 +61,7 @@ class DrawView(context: Context?, attrs: AttributeSet?) : View(context, attrs) {
             when (drawObject) {
                 is DrawObject.Rectangle -> drawRectangle(canvas, drawObject)
                 is DrawObject.Image -> drawImage(canvas, drawObject)
-                is DrawObject.CustomTextView -> drawCustomTextView(canvas, drawObject)
+                is DrawObject.CustomText -> drawCustomTextView(canvas, drawObject)
             }
         }
 
@@ -86,7 +86,7 @@ class DrawView(context: Context?, attrs: AttributeSet?) : View(context, attrs) {
             when (temporaryDrawObject) {
                 is DrawObject.Rectangle -> drawRectangle(canvas, it as DrawObject.Rectangle)
                 is DrawObject.Image -> drawImage(canvas, it as DrawObject.Image)
-                is DrawObject.CustomTextView -> drawCustomTextView(canvas, it as DrawObject.CustomTextView)
+                is DrawObject.CustomText -> drawCustomTextView(canvas, it as DrawObject.CustomText)
                 else -> return
             }
         }
@@ -122,7 +122,7 @@ class DrawView(context: Context?, attrs: AttributeSet?) : View(context, attrs) {
         }
     }
 
-    private fun drawCustomTextView(canvas: Canvas?, customTextView: DrawObject.CustomTextView) = with(customTextView) {
+    private fun drawCustomTextView(canvas: Canvas?, customText: DrawObject.CustomText) = with(customText) {
         val textViewPaint = Paint()
         textViewPaint.textSize = paint.textSize
         textViewPaint.color = Color.argb(
@@ -214,7 +214,7 @@ class DrawView(context: Context?, attrs: AttributeSet?) : View(context, attrs) {
                 )
             }
 
-            is DrawObject.CustomTextView -> {
+            is DrawObject.CustomText -> {
                 val paint = Paint()
                 paint.textSize = drawObject.paint.textSize
                 paint.color = Color.argb((255 * 0.5).toInt(), drawObject.paint.color.red, drawObject.paint.color.green, drawObject.paint.color.blue)

--- a/app/src/main/res/drawable/ic_baseline_crop_square_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_crop_square_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M18,4L6,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,6c0,-1.1 -0.9,-2 -2,-2zM18,18L6,18L6,6h12v12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_image_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_image_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_text_format_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_text_format_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M5,17v2h14v-2L5,17zM9.5,12.8h5l0.9,2.2h2.1L12.75,4h-1.5L6.5,15h2.1l0.9,-2.2zM12,5.98L13.87,11h-3.74L12,5.98z"/>
+</vector>

--- a/app/src/main/res/drawable/layout_border.xml
+++ b/app/src/main/res/drawable/layout_border.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="0.5dp"
+        android:color="@color/black" />
+
+</shape>

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -8,6 +8,29 @@
     android:background="@color/grey"
     tools:context=".MainActivity">
 
+    <LinearLayout
+        android:id="@+id/layout_object_list"
+        android:layout_width="130dp"
+        android:layout_height="match_parent"
+        android:background="@drawable/layout_border"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/drawView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="30dp"
+            android:background="@drawable/layout_border"
+            android:gravity="bottom"
+            android:paddingStart="4dp"
+            android:text="@string/layer_string"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
     <com.example.kotlin_drawingapp.model.draw.DrawView
         android:id="@+id/drawView"
         android:layout_width="0dp"
@@ -16,7 +39,7 @@
         android:background="@color/white"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/layout_object_list"
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -30,7 +53,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/btn_generate_image"
         app:layout_constraintHorizontal_chainStyle="packed"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toEndOf="@id/layout_object_list" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_generate_image"
@@ -128,21 +151,21 @@
         android:id="@+id/number_up_down_x"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:titleValue="X"
         android:layout_margin="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/drawView"
-        app:layout_constraintTop_toBottomOf="@id/textview_position" />
+        app:layout_constraintTop_toBottomOf="@id/textview_position"
+        app:titleValue="X" />
 
     <com.example.kotlin_drawingapp.customview.NumberUpDownView
         android:id="@+id/number_up_down_y"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="4dp"
-        app:titleValue="Y"
-        app:layout_constraintStart_toEndOf="@id/drawView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/number_up_down_x" />
+        app:layout_constraintStart_toEndOf="@id/drawView"
+        app:layout_constraintTop_toBottomOf="@id/number_up_down_x"
+        app:titleValue="Y" />
 
     <TextView
         android:id="@+id/textview_size"
@@ -161,20 +184,20 @@
         android:id="@+id/number_up_down_width"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:titleValue="W"
         android:layout_margin="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/drawView"
-        app:layout_constraintTop_toBottomOf="@id/textview_size" />
+        app:layout_constraintTop_toBottomOf="@id/textview_size"
+        app:titleValue="W" />
 
     <com.example.kotlin_drawingapp.customview.NumberUpDownView
         android:id="@+id/number_up_down_height"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="4dp"
-        app:titleValue="H"
-        app:layout_constraintStart_toEndOf="@id/drawView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/number_up_down_width" />
+        app:layout_constraintStart_toEndOf="@id/drawView"
+        app:layout_constraintTop_toBottomOf="@id/number_up_down_width"
+        app:titleValue="H" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -8,28 +8,30 @@
     android:background="@color/grey"
     tools:context=".MainActivity">
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/textview_layer_string"
+        android:layout_width="0dp"
+        android:layout_height="30dp"
+        android:background="@drawable/layout_border"
+        android:gravity="bottom"
+        android:paddingStart="4dp"
+        android:text="@string/layer_string"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toStartOf="@id/drawView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.example.kotlin_drawingapp.customview.CustomLayerListView
         android:id="@+id/layout_object_list"
         android:layout_width="130dp"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:background="@drawable/layout_border"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/drawView"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="30dp"
-            android:background="@drawable/layout_border"
-            android:gravity="bottom"
-            android:paddingStart="4dp"
-            android:text="@string/layer_string"
-            android:textSize="12sp"
-            android:textStyle="bold" />
-
-    </LinearLayout>
+        app:layout_constraintTop_toBottomOf="@id/textview_layer_string" />
 
     <com.example.kotlin_drawingapp.model.draw.DrawView
         android:id="@+id/drawView"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,29 +8,30 @@
     android:background="@color/grey"
     tools:context=".MainActivity">
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/textview_layer_string"
+        android:layout_width="0dp"
+        android:layout_height="30dp"
+        android:background="@drawable/layout_border"
+        android:gravity="bottom"
+        android:paddingStart="4dp"
+        android:text="@string/layer_string"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toStartOf="@id/drawView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.example.kotlin_drawingapp.customview.CustomLayerListView
         android:id="@+id/layout_object_list"
         android:layout_width="80dp"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:background="@drawable/layout_border"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/drawView"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="30dp"
-            android:background="@drawable/layout_border"
-            android:gravity="bottom"
-            android:paddingStart="4dp"
-            android:text="@string/layer_string"
-            android:textSize="12sp"
-            android:textStyle="bold" />
-
-    </LinearLayout>
-
+        app:layout_constraintTop_toBottomOf="@id/textview_layer_string" />
 
     <com.example.kotlin_drawingapp.model.draw.DrawView
         android:id="@+id/drawView"
@@ -45,7 +46,7 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_generate_rect"
-        android:layout_width="60dp"
+        android:layout_width="80dp"
         android:layout_height="wrap_content"
         android:background="@drawable/tools_left_position"
         android:text="@string/rectangle_string"
@@ -58,7 +59,7 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_generate_image"
-        android:layout_width="60dp"
+        android:layout_width="80dp"
         android:layout_height="wrap_content"
         android:background="@drawable/tools_middle_position"
         android:text="@string/image_string"
@@ -71,7 +72,7 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_generate_textview"
-        android:layout_width="60dp"
+        android:layout_width="80dp"
         android:layout_height="wrap_content"
         android:background="@drawable/tools_right_position"
         android:text="@string/text_string"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,6 +8,30 @@
     android:background="@color/grey"
     tools:context=".MainActivity">
 
+    <LinearLayout
+        android:id="@+id/layout_object_list"
+        android:layout_width="80dp"
+        android:layout_height="match_parent"
+        android:background="@drawable/layout_border"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/drawView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="30dp"
+            android:background="@drawable/layout_border"
+            android:gravity="bottom"
+            android:paddingStart="4dp"
+            android:text="@string/layer_string"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+
     <com.example.kotlin_drawingapp.model.draw.DrawView
         android:id="@+id/drawView"
         android:layout_width="0dp"
@@ -16,12 +40,12 @@
         android:background="@color/white"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/layout_object_list"
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_generate_rect"
-        android:layout_width="80dp"
+        android:layout_width="60dp"
         android:layout_height="wrap_content"
         android:background="@drawable/tools_left_position"
         android:text="@string/rectangle_string"
@@ -30,11 +54,11 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/btn_generate_image"
         app:layout_constraintHorizontal_chainStyle="packed"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toEndOf="@id/layout_object_list" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_generate_image"
-        android:layout_width="80dp"
+        android:layout_width="60dp"
         android:layout_height="wrap_content"
         android:background="@drawable/tools_middle_position"
         android:text="@string/image_string"
@@ -47,7 +71,7 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_generate_textview"
-        android:layout_width="80dp"
+        android:layout_width="60dp"
         android:layout_height="wrap_content"
         android:background="@drawable/tools_right_position"
         android:text="@string/text_string"
@@ -128,21 +152,21 @@
         android:id="@+id/number_up_down_x"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:titleValue="X"
         android:layout_margin="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/drawView"
-        app:layout_constraintTop_toBottomOf="@id/textview_position" />
+        app:layout_constraintTop_toBottomOf="@id/textview_position"
+        app:titleValue="X" />
 
     <com.example.kotlin_drawingapp.customview.NumberUpDownView
         android:id="@+id/number_up_down_y"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="4dp"
-        app:titleValue="Y"
-        app:layout_constraintStart_toEndOf="@id/drawView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/number_up_down_x" />
+        app:layout_constraintStart_toEndOf="@id/drawView"
+        app:layout_constraintTop_toBottomOf="@id/number_up_down_x"
+        app:titleValue="Y" />
 
     <TextView
         android:id="@+id/textview_size"
@@ -161,20 +185,20 @@
         android:id="@+id/number_up_down_width"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:titleValue="W"
         android:layout_margin="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/drawView"
-        app:layout_constraintTop_toBottomOf="@id/textview_size" />
+        app:layout_constraintTop_toBottomOf="@id/textview_size"
+        app:titleValue="W" />
 
     <com.example.kotlin_drawingapp.customview.NumberUpDownView
         android:id="@+id/number_up_down_height"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="4dp"
-        app:titleValue="H"
-        app:layout_constraintStart_toEndOf="@id/drawView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/number_up_down_width" />
+        app:layout_constraintStart_toEndOf="@id/drawView"
+        app:layout_constraintTop_toBottomOf="@id/number_up_down_width"
+        app:titleValue="H" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
     <string name="size_string">크기</string>
     <string name="image_string">사진</string>
     <string name="text_string">텍스트</string>
+    <string name="layer_string">레이어</string>
 </resources>


### PR DESCRIPTION
피드백에 대한 질문을 하던도중에 머지가 돼서 그런지 각 피드백에 코멘트가 안달리더라구요.
마스터클래스 수업을 듣고 다시 한 번 살펴봤는데 전에는 생각못했던 몇 가지 궁금한 점이 생겨서 질문드립니다.

---

**첫 번째 피드백 질문**
  - 제가 뭘 잘못 만졌는지 해당 코멘트가 사라졌더라구요.. [여기](https://github.com/codesquad-members-2022/kotlin-drawingapp/pull/42/commits/792e56c0bfece92e5b7a4baf88fe44f13a406727#diff-aeffb9147d4fd61a5542b0ce0e548574798d15e3267cea38d4009f33c3e857e1R57) 에서 `두 클래스가 data class 였군요! 이 부분은 못봤습니다, 약간 마음에 걸리는게 있는데요 클래스 시간에 다시 말씀드리겠습니다~` 라고 코멘트 해주셨습니다.

    - 제 코드가 지금 `DrawObject`를 sealed class로 선언하고 내부에 Rectangle, Image, CustomText의 데이터 클래스가 존재하는데, 이 3개의 객체는 공통적으로 갖고 있을 수 있는 선택유무, 위치, 사이즈 상태를 갖고 있습니다. sealed class 내부에서는 이런식으로 공통된 기능이나 상태를 나타내도 괜찮은가요? 

    - 데이터 클래스에 Point, Size, List같은 자료형을 선언할 경우 copy로 복사하면 얕은 복사가 돼서, 복사본 수정시 원본까지 수정되는 부분이 있었습니다. 이럴땐 어떤 방식으로 하는게 나을까요?

    - 인터페이스에서 변수를 가지고 있으면 안되나요? 클래스 시간때 상태 관련된건 인터페이스에 있으면 안된다고 하셨던거같아서 코드 샘플들을 몇 개 살펴봤는데 대부분 메소드들만 가지고 있어서요. 인터페이스가 공통적으로 사용할 것들을 정의하는 것으로 이해했는데, 그렇다면 Point나 Size같은 것들도 공통적으로 사용한다면 포함되어도 괜찮지 않을까 라는 생각이 들었습니다.

---

**[두 번째 피드백](https://github.com/codesquad-members-2022/kotlin-drawingapp/pull/42#discussion_r827851051) 적용**
  - 클래스명을 `CustomTextView` 에서 `CustomText`로 변경하였습니다.

---

**[세 번째 피드백](https://github.com/codesquad-members-2022/kotlin-drawingapp/pull/42#discussion_r827857460) 질문**
  -  Factory에는 객체를 생성하는데 필요한 정보들을 다 구현해서 전달해야 된다고 생각했습니다. 필수적으로 필요한 부분을 제외하고는 CustomText 클래스에서 처리해야된다는 말씀이신건지 궁금합니다.

---

## 오브젝트 목록 표시 일부 구현
  - 현재 추가된 리스트를 표현할 수 있도록 구현
    - 리스트에 추가될 TextView를 상속받은 커스텀 뷰(CustomLayerTextView)와 리스트를 표현할 LinearLayout을 상속받은 커스텀 뷰(CustomLayerListView) 구현
  - 오브젝트 리스트에서 객체 클릭 시 선택되도록 구현
    - 위 두 개의 커스텀뷰에 리스너를 등록해서 CustomLayerTextView가 클릭되면 ListView로 전달하고, ListView에서 메인으로 전달하도록 구현
  

### 개선할 점
  - 새로 그려질 때마다 오브젝트 리스트에 removeAllViews와 addView를 사용해서 깜빡이는 현상 발생

### 미구현한 부분
  - 메뉴 및 위치 변경
