### PR TITLE
[히데]  리스트 레이어  각 아이템 썸네일 이미지 구현,  롱클릭 이벤트처리  

### DIFF
--- a/app/src/main/java/view/CustomRectInfoView.kt
+++ b/app/src/main/java/view/CustomRectInfoView.kt
@@ -1,6 +1,7 @@
 package view
 
 import android.content.Context
+import android.graphics.Color
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.ImageView
@@ -24,7 +25,15 @@ class CustomRectInfoView(
         val text: TextView = findViewById(R.id.tv_name)
         val image: ImageView = findViewById(R.id.iv_figure)
         text.text = name
+        this.setBackgroundColor(Color.WHITE)
     }
 
+    fun selected(){
+        this.setBackgroundColor(Color.GRAY)
+    }
+
+    fun resetColor(){
+        this.setBackgroundColor(Color.WHITE)
+    }
 
 }

--- a/app/src/main/java/view/CustomRectInfoView.kt
+++ b/app/src/main/java/view/CustomRectInfoView.kt
@@ -20,10 +20,11 @@ class CustomRectInfoView(
 
     var rectId=""
     val photoId=""
+    var image: ImageView
     init {
         LayoutInflater.from(context).inflate(R.layout.customview_layer, this, true)
         val text: TextView = findViewById(R.id.tv_name)
-        val image: ImageView = findViewById(R.id.iv_figure)
+        image= findViewById(R.id.iv_figure)
         text.text = name
         this.setBackgroundColor(Color.WHITE)
     }

--- a/app/src/main/java/view/MainActivity.kt
+++ b/app/src/main/java/view/MainActivity.kt
@@ -4,16 +4,14 @@ import MainPresenter
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Color
-import android.graphics.ImageDecoder
+import android.graphics.*
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.provider.Settings
 import android.view.MotionEvent
+import android.view.View
 import android.widget.*
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -24,6 +22,9 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import com.codesquad.kotlin_drawingapp.R
 import model.*
+import model.Point
+import model.Rect
+
 
 private const val REQUEST_CODE = 1000
 
@@ -342,6 +343,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
     }
 
 
+
     override fun onRequestPermissionsResult(
         requestCode: Int,
         permissions: Array<String>, grantResults: IntArray
@@ -558,6 +560,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         mainLayout.addView(rectView)
         customRectangleViewList.add(rectView)
         customRectInfoViewList[rectCount].rectId = rect.rectId
+        customRectInfoViewList[rectCount].image.setImageBitmap(rectView.getBitmapFromView())
         rectCount++
     }
 
@@ -568,6 +571,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         mainLayout.addView(rectView)
         customRectangleViewList.add(rectView)
         customRectInfoViewList[rectCount].rectId = photo.rectId
+        customRectInfoViewList[rectCount].image.setImageBitmap(rectView.getThumbnailPhoto())
         rectCount++
     }
 
@@ -577,6 +581,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         mainLayout.addView(rectView)
         customRectangleViewList.add(rectView)
         customRectInfoViewList[rectCount].rectId = sentence.rectId
+        customRectInfoViewList[rectCount].image.setImageBitmap(rectView.getBitmapFromView())
         rectCount++
     }
 

--- a/app/src/main/java/view/MainActivity.kt
+++ b/app/src/main/java/view/MainActivity.kt
@@ -96,14 +96,70 @@ class MainActivity : AppCompatActivity(), MainContract.View {
             layer.addView(customLayerView)
             customRectInfoViewList.add(customLayerView)
             presenter.createRectanglePaint()
-            customLayerView.setOnClickListener {
+            customLayerView.setOnClickListener { view ->
+                view as CustomRectInfoView
                 customRectangleViewList.map { it.eraseBorder() }
-                customRectInfoViewList.map{it.resetColor()}
-                it.setBackgroundColor(Color.GRAY)
+                customRectInfoViewList.map { it.resetColor() }
+                view.setBackgroundColor(Color.GRAY)
                 selectedRectangle?.opacity?.removeObserver(opacityObserver)
                 selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
-                presenter.selectRectangleByList(customLayerView.rectId)
+                presenter.selectRectangleByList(view.rectId)
             }
+            customLayerView.setOnLongClickListener { view ->
+                view as CustomRectInfoView
+                val popupMenu = PopupMenu(this, view)
+                val mInflater = this.menuInflater
+                mInflater.inflate(R.menu.list_longclick_menu, popupMenu.menu)
+                popupMenu.setOnMenuItemClickListener {
+                    val indexOfSelectedItem = customRectInfoViewList.indexOf(view)
+                    customRectInfoViewList.map { originView ->
+                        layer.removeView(originView)
+                    }
+                    when (it.itemId) {
+
+                        R.id.item_move_back -> {
+                            if (indexOfSelectedItem >= 1) {
+                                val temp = customRectInfoViewList[indexOfSelectedItem - 1]
+                                customRectInfoViewList[indexOfSelectedItem - 1] = view
+                                customRectInfoViewList[indexOfSelectedItem] = temp
+                            }
+                        }
+                        R.id.item_move_front -> {
+                            if (indexOfSelectedItem + 1 < customRectInfoViewList.size) {
+                                val temp = customRectInfoViewList[indexOfSelectedItem + 1]
+                                customRectInfoViewList[indexOfSelectedItem + 1] = view
+                                customRectInfoViewList[indexOfSelectedItem] = temp
+                            }
+                        }
+                        R.id.item_move_head -> {
+                            val temp: ArrayList<CustomRectInfoView> = ArrayList(100)
+                            customRectInfoViewList.remove(view)
+                            temp.add(view)
+                            customRectInfoViewList.map { info ->
+                                temp.add(info)
+                            }
+                            this.customRectInfoViewList = temp
+                        }
+                        R.id.item_move_tail -> {
+                            val temp: ArrayList<CustomRectInfoView> = ArrayList(100)
+                            customRectInfoViewList.remove(view)
+                            customRectInfoViewList.map { info ->
+                                temp.add(info)
+                            }
+                            temp.add(view)
+                            this.customRectInfoViewList = temp
+                        }
+
+                    }
+                    customRectInfoViewList.map { modifyView ->
+                        layer.addView(modifyView)
+                    }
+                    true
+                }
+                popupMenu.show()
+                true
+            }
+
 
         }
 
@@ -133,14 +189,70 @@ class MainActivity : AppCompatActivity(), MainContract.View {
             layer.addView(customLayerView)
             customRectInfoViewList.add(customLayerView)
             presenter.createSentencePaint()
-            customLayerView.setOnClickListener {
+            customLayerView.setOnClickListener { view ->
+                view as CustomRectInfoView
                 customRectangleViewList.map { it.eraseBorder() }
-                customRectInfoViewList.map{it.resetColor()}
-                it.setBackgroundColor(Color.GRAY)
+                customRectInfoViewList.map { it.resetColor() }
+                view.setBackgroundColor(Color.GRAY)
                 selectedRectangle?.opacity?.removeObserver(opacityObserver)
                 selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
-                presenter.selectRectangleByList(customLayerView.rectId)
+                presenter.selectRectangleByList(view.rectId)
             }
+            customLayerView.setOnLongClickListener { view ->
+                view as CustomRectInfoView
+                val popupMenu = PopupMenu(this, view)
+                val mInflater = this.menuInflater
+                mInflater.inflate(R.menu.list_longclick_menu, popupMenu.menu)
+                popupMenu.setOnMenuItemClickListener {
+                    val indexOfSelectedItem = customRectInfoViewList.indexOf(view)
+                    customRectInfoViewList.map { originView ->
+                        layer.removeView(originView)
+                    }
+                    when (it.itemId) {
+
+                        R.id.item_move_back -> {
+                            if (indexOfSelectedItem >= 1) {
+                                val temp = customRectInfoViewList[indexOfSelectedItem - 1]
+                                customRectInfoViewList[indexOfSelectedItem - 1] = view
+                                customRectInfoViewList[indexOfSelectedItem] = temp
+                            }
+                        }
+                        R.id.item_move_front -> {
+                            if (indexOfSelectedItem + 1 < customRectInfoViewList.size) {
+                                val temp = customRectInfoViewList[indexOfSelectedItem + 1]
+                                customRectInfoViewList[indexOfSelectedItem + 1] = view
+                                customRectInfoViewList[indexOfSelectedItem] = temp
+                            }
+                        }
+                        R.id.item_move_head -> {
+                            val temp: ArrayList<CustomRectInfoView> = ArrayList(100)
+                            customRectInfoViewList.remove(view)
+                            temp.add(view)
+                            customRectInfoViewList.map { info ->
+                                temp.add(info)
+                            }
+                            this.customRectInfoViewList = temp
+                        }
+                        R.id.item_move_tail -> {
+                            val temp: ArrayList<CustomRectInfoView> = ArrayList(100)
+                            customRectInfoViewList.remove(view)
+                            customRectInfoViewList.map { info ->
+                                temp.add(info)
+                            }
+                            temp.add(view)
+                            this.customRectInfoViewList = temp
+                        }
+
+                    }
+                    customRectInfoViewList.map { modifyView ->
+                        layer.addView(modifyView)
+                    }
+                    true
+                }
+                popupMenu.show()
+                true
+            }
+
 
         }
         mainLayout.setOnTouchListener { _, motionEvent ->
@@ -229,6 +341,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
         }
     }
 
+
     override fun onRequestPermissionsResult(
         requestCode: Int,
         permissions: Array<String>, grantResults: IntArray
@@ -294,13 +407,71 @@ class MainActivity : AppCompatActivity(), MainContract.View {
                         layer.addView(customLayerView)
                         customRectInfoViewList.add(customLayerView)
                         presenter.createPhotoPaint(bitmap)
-                        customLayerView.setOnClickListener {
+                        customLayerView.setOnClickListener { view ->
+                            view as CustomRectInfoView
                             customRectangleViewList.map { it.eraseBorder() }
-                            customRectInfoViewList.map{it.resetColor()}
-                            it.setBackgroundColor(Color.GRAY)
+                            customRectInfoViewList.map { it.resetColor() }
+                            view.setBackgroundColor(Color.GRAY)
                             selectedRectangle?.opacity?.removeObserver(opacityObserver)
                             selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
-                            presenter.selectRectangleByList(customLayerView.rectId)
+
+                            presenter.selectRectangleByList(view.rectId)
+                        }
+                        customLayerView.setOnLongClickListener { view ->
+                            view as CustomRectInfoView
+                            val popupMenu = PopupMenu(this, view)
+                            val mInflater = this.menuInflater
+                            mInflater.inflate(R.menu.list_longclick_menu, popupMenu.menu)
+                            popupMenu.setOnMenuItemClickListener {
+                                val indexOfSelectedItem = customRectInfoViewList.indexOf(view)
+                                customRectInfoViewList.map { originView ->
+                                    layer.removeView(originView)
+                                }
+                                when (it.itemId) {
+
+                                    R.id.item_move_back -> {
+                                        if (indexOfSelectedItem >= 1) {
+                                            val temp =
+                                                customRectInfoViewList[indexOfSelectedItem - 1]
+                                            customRectInfoViewList[indexOfSelectedItem - 1] = view
+                                            customRectInfoViewList[indexOfSelectedItem] = temp
+                                        }
+                                    }
+                                    R.id.item_move_front -> {
+                                        if (indexOfSelectedItem + 1 < customRectInfoViewList.size) {
+                                            val temp =
+                                                customRectInfoViewList[indexOfSelectedItem + 1]
+                                            customRectInfoViewList[indexOfSelectedItem + 1] = view
+                                            customRectInfoViewList[indexOfSelectedItem] = temp
+                                        }
+                                    }
+                                    R.id.item_move_head -> {
+                                        val temp: ArrayList<CustomRectInfoView> = ArrayList(100)
+                                        customRectInfoViewList.remove(view)
+                                        temp.add(view)
+                                        customRectInfoViewList.map { info ->
+                                            temp.add(info)
+                                        }
+                                        this.customRectInfoViewList = temp
+                                    }
+                                    R.id.item_move_tail -> {
+                                        val temp: ArrayList<CustomRectInfoView> = ArrayList(100)
+                                        customRectInfoViewList.remove(view)
+                                        customRectInfoViewList.map { info ->
+                                            temp.add(info)
+                                        }
+                                        temp.add(view)
+                                        this.customRectInfoViewList = temp
+                                    }
+
+                                }
+                                customRectInfoViewList.map { modifyView ->
+                                    layer.addView(modifyView)
+                                }
+                                true
+                            }
+                            popupMenu.show()
+                            true
                         }
                     }
 
@@ -375,6 +546,7 @@ class MainActivity : AppCompatActivity(), MainContract.View {
                     presenter.changePosition(it)
                 }
             }
+
             true
         }
 

--- a/app/src/main/java/view/MainActivity.kt
+++ b/app/src/main/java/view/MainActivity.kt
@@ -6,13 +6,13 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Color
 import android.graphics.ImageDecoder
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.provider.Settings
-import android.util.Log
 import android.view.MotionEvent
 import android.widget.*
 import androidx.activity.result.ActivityResultLauncher
@@ -97,8 +97,9 @@ class MainActivity : AppCompatActivity(), MainContract.View {
             customRectInfoViewList.add(customLayerView)
             presenter.createRectanglePaint()
             customLayerView.setOnClickListener {
-                Log.d("test","Clcicked")
                 customRectangleViewList.map { it.eraseBorder() }
+                customRectInfoViewList.map{it.resetColor()}
+                it.setBackgroundColor(Color.GRAY)
                 selectedRectangle?.opacity?.removeObserver(opacityObserver)
                 selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
                 presenter.selectRectangleByList(customLayerView.rectId)
@@ -134,6 +135,8 @@ class MainActivity : AppCompatActivity(), MainContract.View {
             presenter.createSentencePaint()
             customLayerView.setOnClickListener {
                 customRectangleViewList.map { it.eraseBorder() }
+                customRectInfoViewList.map{it.resetColor()}
+                it.setBackgroundColor(Color.GRAY)
                 selectedRectangle?.opacity?.removeObserver(opacityObserver)
                 selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
                 presenter.selectRectangleByList(customLayerView.rectId)
@@ -141,14 +144,13 @@ class MainActivity : AppCompatActivity(), MainContract.View {
 
         }
         mainLayout.setOnTouchListener { _, motionEvent ->
-            Log.d("test","Touched")
             if (motionEvent.action == MotionEvent.ACTION_DOWN) {
                 customRectangleViewList.map { it.eraseBorder() }
                 selectedRectangle?.opacity?.removeObserver(opacityObserver)
                 selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
                 presenter.selectRectangle(motionEvent.x, motionEvent.y)
             }
-            true
+            false
         }
 
 
@@ -294,6 +296,8 @@ class MainActivity : AppCompatActivity(), MainContract.View {
                         presenter.createPhotoPaint(bitmap)
                         customLayerView.setOnClickListener {
                             customRectangleViewList.map { it.eraseBorder() }
+                            customRectInfoViewList.map{it.resetColor()}
+                            it.setBackgroundColor(Color.GRAY)
                             selectedRectangle?.opacity?.removeObserver(opacityObserver)
                             selectedRectangle?.backGroundColor?.removeObserver(backgroundObserver)
                             presenter.selectRectangleByList(customLayerView.rectId)
@@ -363,9 +367,10 @@ class MainActivity : AppCompatActivity(), MainContract.View {
             if (motionEvent.action == MotionEvent.ACTION_MOVE) {
                 selectedCustomRectangleView?.onTouch(motionEvent, tempView)
                 tempView.invalidate()
-            } else if (motionEvent.action == MotionEvent.ACTION_UP) {
+            }
+            if (motionEvent.action == MotionEvent.ACTION_UP) {
                 selectedCustomRectangleView?.let {
-                    it.onTouch(motionEvent, tempView)
+                    it.changePos(motionEvent.x, motionEvent.y)
                     mainLayout.removeView(tempView)
                     presenter.changePosition(it)
                 }

--- a/app/src/main/java/view/RectView.kt
+++ b/app/src/main/java/view/RectView.kt
@@ -9,10 +9,12 @@ import android.text.TextPaint
 import android.util.Log
 import android.view.MotionEvent
 import android.view.View
+import android.widget.TextView
 import model.BackGroundColor
 import model.Photo
 import model.Rect
 import model.Sentence
+import java.lang.IllegalArgumentException
 
 
 class RectView(context: Context) : View(context) {
@@ -244,6 +246,31 @@ class RectView(context: Context) : View(context) {
         this.top= yPos
         this.bottom= this.top + this.rectHeight
         invalidate()
+    }
+
+    fun getBitmapFromView(): Bitmap? {
+        val bitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        if(this.backGroundRGB.isNotEmpty()) {
+            try {
+                val color = Color.parseColor(this.backGroundRGB)
+                canvas.drawColor(color)
+            } catch (e: IllegalArgumentException) {
+                canvas.drawColor(Color.BLACK)
+            }
+        }
+        this.draw(canvas)
+        return bitmap
+    }
+
+    fun getThumbnailPhoto():Bitmap?{
+        this.bitmap?.let{
+            val thumbnail = Bitmap.createBitmap(it)
+            thumbnail?.width= 40
+            thumbnail?.height=40
+            return thumbnail
+        }
+        return null
     }
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,14 +7,44 @@
     android:layout_height="match_parent"
     tools:context="view.MainActivity">
 
+    <LinearLayout
+        android:id="@+id/linear_list"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:background="@color/sideBar"
+        android:orientation="vertical"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_list_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="50dp"
+            android:layout_marginTop="50dp"
+            android:layout_marginRight="50dp"
+            android:text="리스트"
+            android:textColor="@color/black"
+
+            >
+
+        </TextView>
+    </LinearLayout>
+
     <FrameLayout
         android:id="@+id/image_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:layout_editor_absoluteX="-421dp"
-        tools:layout_editor_absoluteY="16dp" />
+        android:layout_width="1300dp"
+        android:layout_height="900dp"
+        app:layout_constraintEnd_toStartOf="@+id/relativeLayout"
+        app:layout_constraintStart_toEndOf="@+id/linear_list"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        >
+
+    </FrameLayout>
 
     <RelativeLayout
+        android:id="@+id/relativeLayout"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:background="@color/sideBar"
@@ -29,15 +59,14 @@
             android:layout_marginTop="50dp"
             android:layout_marginRight="50dp"
             android:text="배경색"
-            android:textColor="@color/black"
-            />
+            android:textColor="@color/black" />
 
         <TextView
             android:id="@+id/tv_rgb_value"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@id/tv_rgb_title"
-            android:layout_marginLeft="32dp"
+            android:layout_marginStart="32dp"
             android:layout_marginTop="15dp"
             android:background="@drawable/imageview_border"
             android:padding="10dp"
@@ -62,8 +91,244 @@
             android:layout_below="@id/tv_alpha_title"
             android:layout_marginLeft="10dp"
             android:layout_marginTop="15dp"
-            android:max="10"
-            android:layout_marginRight="10dp" />
+            android:layout_marginRight="10dp"
+            android:max="10" />
+
+        <TextView
+            android:id="@+id/tv_pos_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/seekbar_opacity"
+            android:layout_marginLeft="50dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginRight="50dp"
+            android:text="위치 "
+            android:textColor="@color/black"
+
+            />
+
+        <LinearLayout
+            android:id="@+id/linear_xPos"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv_pos_title"
+            android:layout_marginStart="15dp"
+            android:layout_marginEnd="15dp"
+            android:background="@drawable/imageview_border"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tv_xPos_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:text="X"
+                android:textSize="18sp">
+
+            </TextView>
+
+            <EditText
+                android:id="@+id/editText_xPos"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ems="4"
+                android:inputType="number" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/btn_xPos_up"
+                    android:layout_width="20dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_baseline_arrow_drop_up_24">
+
+                </Button>
+
+                <Button
+                    android:id="@+id/btn_xPos_down"
+                    android:layout_width="20dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_baseline_arrow_drop_down_24" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/linear_yPos"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/linear_xPos"
+            android:layout_marginStart="15dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="15dp"
+            android:background="@drawable/imageview_border"
+            android:orientation="horizontal">
+
+
+            <TextView
+                android:id="@+id/tv_yPos_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:text="Y"
+                android:textSize="18sp">
+
+            </TextView>
+
+            <EditText
+                android:id="@+id/editText_yPos"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ems="4"
+                android:inputType="number" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/btn_yPos_up"
+                    android:layout_width="20dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_baseline_arrow_drop_up_24">
+
+                </Button>
+
+                <Button
+                    android:id="@+id/btn_yPos_down"
+                    android:layout_width="20dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_baseline_arrow_drop_down_24" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tv_size_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/linear_yPos"
+            android:layout_marginLeft="50dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginRight="50dp"
+            android:text="크기 "
+            android:textColor="@color/black"
+
+            />
+
+        <LinearLayout
+            android:id="@+id/linear_width"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv_size_title"
+            android:layout_marginStart="15dp"
+            android:layout_marginEnd="15dp"
+            android:background="@drawable/imageview_border"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tv_width_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingEnd="6dp"
+                android:text="W"
+                android:textSize="18sp">
+
+            </TextView>
+
+            <EditText
+                android:id="@+id/editText_width"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ems="4"
+                android:inputType="number" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/btn_width_up"
+                    android:layout_width="20dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_baseline_arrow_drop_up_24">
+
+                </Button>
+
+                <Button
+                    android:id="@+id/btn_width_down"
+                    android:layout_width="20dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_baseline_arrow_drop_down_24" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/linear_height"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/linear_width"
+            android:layout_marginStart="15dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="15dp"
+            android:background="@drawable/imageview_border"
+            android:orientation="horizontal">
+
+
+            <TextView
+                android:id="@+id/tv_height_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:text="H"
+                android:textSize="18sp">
+
+            </TextView>
+
+            <EditText
+                android:id="@+id/editText_height"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ems="4"
+                android:inputType="number" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/btn_height_up"
+                    android:layout_width="20dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_baseline_arrow_drop_up_24">
+
+                </Button>
+
+                <Button
+                    android:id="@+id/btn_height_down"
+                    android:layout_width="20dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_baseline_arrow_drop_down_24" />
+            </LinearLayout>
+        </LinearLayout>
 
     </RelativeLayout>
 
@@ -81,6 +346,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
     <Button
         android:id="@+id/btn_addPhoto"
         android:layout_width="wrap_content"
@@ -95,4 +361,19 @@
         app:layout_constraintBottom_toBottomOf="parent"
 
         app:layout_constraintStart_toEndOf="@id/btn_addRectangle" />
+
+
+    <Button
+        android:id="@+id/btn_addSentence"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:paddingTop="30dp"
+        android:paddingBottom="10dp"
+        android:text="₸\n텍스트"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn_addPhoto" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/list_longclick_menu.xml
+++ b/app/src/main/res/menu/list_longclick_menu.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:title="맨 앞으로 가기"
+        android:id="@+id/item_move_head"
+        />
+    <item
+        android:title="맨 뒤로 가기"
+        android:id="@+id/item_move_tail"
+        />
+    <item
+        android:title="앞으로 가기"
+        android:id="@+id/item_move_front"
+        />
+    <item
+        android:title="뒤로 가기"
+        android:id="@+id/item_move_back"
+        />
+</menu>


### PR DESCRIPTION
*   리스트 레이어
   * 리스트 각 아이템의 이미지에 썸네일 (40x40 사이즈) 이미지가 들어가도록 수정 (커스텀 뷰중 텍스트의 경우 썸네일 표시가 정상적으로 되지 않아 수정중)
   * 리스트의 각 아이템 클릭시  배경색 변하며 , 사각형 선택하는 것과 동일한 구현이 되도록 함
   * 각 아이템 롱 클릭시 팝업 메뉴 추가
   * 팝업 메뉴 아이템 클릭시 순서 변경 
   * 바뀐  순서대로 다시 그리는 것은 미구현 
